### PR TITLE
Prevents scan if the code is transpiled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66.0 as build-env
+FROM rust:1.70.0 as build-env
 WORKDIR /app
 COPY . /app
 RUN cargo build --release

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -177,17 +177,15 @@ fn scan_directory(dir: PathBuf, function: Option<&str>, opts: Opts) -> Result<Fo
 
     let paths = collect_sourcefiles(dir.join("src/")).collect::<HashSet<_>>();
 
-    let transpiled_async = paths
-        .iter()
-        .map(|path| {
-            if let Ok(data) = fs::read_to_string(path) {
-                if let Some(line) = data.lines().nth(0) {
-                    return line.contains("\"use strict\";");
-                }
-            }
-            false
-        })
-        .any(|path| path);
+    let transpiled_async = paths.iter().any(|path| {
+        if let Ok(data) = fs::read_to_string(path) {
+            return data
+                .lines()
+                .next()
+                .is_some_and(|data| data == "\"use strict\";" || data == "'use strict';");
+        }
+        false
+    });
 
     let funcrefs = manifest.modules.into_analyzable_functions().flat_map(|f| {
         f.sequence(|fmod| {

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -3,6 +3,7 @@ use std::{
     collections::HashSet,
     convert::TryFrom,
     fs,
+    io::{self, BufReader},
     os::unix::prelude::OsStrExt,
     path::{Path, PathBuf},
     sync::Arc,
@@ -175,6 +176,17 @@ fn scan_directory(dir: PathBuf, function: Option<&str>, opts: Opts) -> Result<Fo
     let name = manifest.app.name.unwrap_or_default();
 
     let paths = collect_sourcefiles(dir.join("src/")).collect::<HashSet<_>>();
+
+    let transpiled_async = paths
+        .iter()
+        .map(|path| {
+            if let Ok(data) = fs::read_to_string(path) {
+                return data.contains("use strict");
+            }
+            false
+        })
+        .any(|path| path);
+
     let funcrefs = manifest.modules.into_analyzable_functions().flat_map(|f| {
         f.sequence(|fmod| {
             let resolved_func = FunctionRef::try_from(fmod)?.try_resolve(&paths, &dir)?;
@@ -183,6 +195,10 @@ fn scan_directory(dir: PathBuf, function: Option<&str>, opts: Opts) -> Result<Fo
     });
     let src_root = dir.join("src");
     let mut proj = ForgeProject::with_files_and_sourceroot(src_root, paths.clone());
+    if transpiled_async {
+        warn!("Unable to scan due to transpiled async");
+        return Ok(proj);
+    }
     proj.opts = opts.clone();
     proj.add_funcs(funcrefs);
     resolve_calls(&mut proj.ctx);

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -181,7 +181,9 @@ fn scan_directory(dir: PathBuf, function: Option<&str>, opts: Opts) -> Result<Fo
         .iter()
         .map(|path| {
             if let Ok(data) = fs::read_to_string(path) {
-                return data.contains("use strict");
+                if let Some(line) = data.lines().nth(0) {
+                    return line.contains("\"use strict\";");
+                }
             }
             false
         })


### PR DESCRIPTION
* This is required for my scanner because we add all permissions initially, and when we find urls we remove the permissions as we go. However, if we can't scan any of the code, then we cannot extract any permissions and creates false positives. This is more efficient because there is no point in scanning anyway if the code is transpiled and cannot be scanned to begin with. 