### PR TITLE
BUG-2199: Fix for the FSRT Multiple Definitions for Same Variable Bug

### DIFF
--- a/crates/forge_analyzer/src/definitions.rs
+++ b/crates/forge_analyzer/src/definitions.rs
@@ -1467,7 +1467,7 @@ impl<'cx> FunctionAnalyzer<'cx> {
                                     let id = ident.to_id();
                                     let new_def =
                                         self.res.get_or_insert_sym(id.clone(), self.module);
-                                    let var_id = self.body.insert_global(new_def);
+                                    let var_id = self.body.get_or_insert_global(new_def);
                                     var.projections.push(Projection::Known(ident.sym.clone()));
                                     self.res
                                         .def_mut(def_id)

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -99,7 +99,6 @@ pub trait Dataflow<'cx>: Sized {
         rvalue: &'cx Rvalue,
         initial_state: Self::State,
     ) -> Self::State {
-        // println!("hi");
         match rvalue {
             Rvalue::Intrinsic(intrinsic, args) => self.transfer_intrinsic(
                 interp,
@@ -419,15 +418,9 @@ impl ValueManager {
         projection_vec: ProjectionVec,
         value: Value,
     ) {
-        // println!("Attempting to insert: defid - {:?} varid - {:?} proj vec - {:?} val - {:?}", def_id_func, var_id, projection_vec[0], value);
-        // println!("Current var mapping with projects: {:?}", self.varid_to_value_with_proj);
-        // println!("Current var mapping with values: {:?}", self.varid_to_value);
         if projection_vec.is_empty() {
-            // println!("EMPTY!");
             self.varid_to_value.insert((def_id_func, var_id), value);
         } else {
-            // println!("NOT EMPTY");
-            // DOES NOT FIX:
             self.varid_to_value_with_proj
                 .insert((def_id_func, var_id, projection_vec), value);
         }
@@ -606,22 +599,13 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
         value: Value,
         projections: ProjectionVec,
     ) {
-        // println!("In add val with proj: Adding new value defid - {:?} varid - {:?} proj vec - {:?} val - {:?}", defid_block, varid, projections, value);
-        // println!("Add val with projection: {:?}", value);
         let (varid, projections) = self.get_farthest_obj(defid_block, varid, projections);
         self.value_manager
             .insert_var_with_projection(defid_block, varid, projections, value);
     }
 
-    // this function takes in an operand checks for previous values and returns a value optional
-    //
-    // SW: This function adds a value to a definition,
-    //      with the input of a DefId, the locator value (points to memory location), and the read value (value to be read).
-    // There are 4 cases - if the existing value
     #[inline]
     pub fn add_value_to_definition(&mut self, defid_block: DefId, lval: Variable, rvalue: Rvalue) {
-        // println!("Entered add val to def function with defid - {:?}, lval - {:?}, rval - {:?}", defid_block, lval, rvalue);
-        // println!("Add val to def: {:?}", rvalue);
         if let Variable {
             base: Base::Var(varid),
             projections,
@@ -633,8 +617,6 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                 .get_value(defid_block, varid, Some(projections.clone()))
                 .cloned()
             {
-                // println!("The existing value: {:?}", existing_lval);
-                // println!("The (current) real value: {:?}", rval_value);
                 // if there is an existing value...
                 match (existing_lval, rval_value) {
                     // return unknown if either values are unknown
@@ -650,10 +632,8 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                         projections,
                     ),
                     // push other const onto phi vec if either are const and phi
-                    // SW: NEED TO MODIFY THIS CASE TO HANDLE REASSIGNMENTS. Hits if we do a reassignment after already having done one.
                     (Value::Const(const_value), Value::Phi(phi_value))
                     | (Value::Phi(phi_value), Value::Const(const_value)) => {
-                        // println!("Entered constant and phi vec match case");
                         let mut new_phi = phi_value;
                         new_phi.push(const_value);
                         self.add_value_with_projection(
@@ -664,7 +644,6 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                         )
                     }
                     // push consts into vec if both are consts
-                    // SW: NEED TO MODIFY THIS CASE TO HANDLE REASSIGNMENTS. Hits if we do a single reassignment.
                     (Value::Const(const_value1), Value::Const(const_value2)) => {
                         self.add_value_with_projection(
                             defid_block,
@@ -672,12 +651,10 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                             Value::Phi(vec![const_value1, const_value2]),
                             projections,
                         );
-                        // println!("Entered double constant match case");
                     }
                     (Value::Object(exist_var), Value::Object(new_var)) => {
                         // store projection values that are transferred
                         let mut projections_transferred = vec![];
-                        // println!("In add val to def - projections transferred are: {:?}", projections_transferred);
                         // transfer all projection values from the new_var into the existing var
                         let start_new = (defid_block, new_var, ProjectionVec::new());
                         let query_new = match new_var.0.checked_add(1) {
@@ -728,7 +705,6 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                 }
             } else {
                 // push the rval if no existing value
-                // println!("No existing value");
                 self.add_value_with_projection(defid_block, varid, rval_value, projections)
             }
         }

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -604,6 +604,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
             .insert_var_with_projection(defid_block, varid, projections, value);
     }
 
+    // this function takes in an operand checks for previous values and returns a value optional
     #[inline]
     pub fn add_value_to_definition(&mut self, defid_block: DefId, lval: Variable, rvalue: Rvalue) {
         if let Variable {

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -99,6 +99,7 @@ pub trait Dataflow<'cx>: Sized {
         rvalue: &'cx Rvalue,
         initial_state: Self::State,
     ) -> Self::State {
+        // println!("hi");
         match rvalue {
             Rvalue::Intrinsic(intrinsic, args) => self.transfer_intrinsic(
                 interp,
@@ -418,9 +419,15 @@ impl ValueManager {
         projection_vec: ProjectionVec,
         value: Value,
     ) {
+        // println!("Attempting to insert: defid - {:?} varid - {:?} proj vec - {:?} val - {:?}", def_id_func, var_id, projection_vec[0], value);
+        // println!("Current var mapping with projects: {:?}", self.varid_to_value_with_proj);
+        // println!("Current var mapping with values: {:?}", self.varid_to_value);
         if projection_vec.is_empty() {
+            // println!("EMPTY!");
             self.varid_to_value.insert((def_id_func, var_id), value);
         } else {
+            // println!("NOT EMPTY");
+            // DOES NOT FIX:
             self.varid_to_value_with_proj
                 .insert((def_id_func, var_id, projection_vec), value);
         }
@@ -599,14 +606,22 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
         value: Value,
         projections: ProjectionVec,
     ) {
+        // println!("In add val with proj: Adding new value defid - {:?} varid - {:?} proj vec - {:?} val - {:?}", defid_block, varid, projections, value);
+        println!("Add val with projection: {:?}", value);
         let (varid, projections) = self.get_farthest_obj(defid_block, varid, projections);
         self.value_manager
             .insert_var_with_projection(defid_block, varid, projections, value);
     }
 
     // this function takes in an operand checks for previous values and returns a value optional
+    //
+    // SW: This function adds a value to a definition,
+    //      with the input of a DefId, the locator value (points to memory location), and the read value (value to be read).
+    // There are 4 cases - if the existing value
     #[inline]
     pub fn add_value_to_definition(&mut self, defid_block: DefId, lval: Variable, rvalue: Rvalue) {
+        // println!("Entered add val to def function with defid - {:?}, lval - {:?}, rval - {:?}", defid_block, lval, rvalue);
+        println!("Add val to def: {:?}", rvalue);
         if let Variable {
             base: Base::Var(varid),
             projections,
@@ -618,6 +633,8 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                 .get_value(defid_block, varid, Some(projections.clone()))
                 .cloned()
             {
+                println!("The existing value: {:?}", existing_lval);
+                // println!("The (current) real value: {:?}", rval_value);
                 // if there is an existing value...
                 match (existing_lval, rval_value) {
                     // return unknown if either values are unknown
@@ -633,8 +650,10 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                         projections,
                     ),
                     // push other const onto phi vec if either are const and phi
+                    // SW: NEED TO MODIFY THIS CASE TO HANDLE REASSIGNMENTS. Hits if we do a reassignment after already having done one.
                     (Value::Const(const_value), Value::Phi(phi_value))
                     | (Value::Phi(phi_value), Value::Const(const_value)) => {
+                        println!("Entered constant and phi vec match case");
                         let mut new_phi = phi_value;
                         new_phi.push(const_value);
                         self.add_value_with_projection(
@@ -645,16 +664,20 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                         )
                     }
                     // push consts into vec if both are consts
-                    (Value::Const(const_value1), Value::Const(const_value2)) => self
-                        .add_value_with_projection(
+                    // SW: NEED TO MODIFY THIS CASE TO HANDLE REASSIGNMENTS. Hits if we do a single reassignment.
+                    (Value::Const(const_value1), Value::Const(const_value2)) => {
+                        self.add_value_with_projection(
                             defid_block,
                             varid,
                             Value::Phi(vec![const_value1, const_value2]),
                             projections,
-                        ),
+                        );
+                        println!("Entered double constant match case");
+                    }
                     (Value::Object(exist_var), Value::Object(new_var)) => {
                         // store projection values that are transferred
                         let mut projections_transferred = vec![];
+                        // println!("In add val to def - projections transferred are: {:?}", projections_transferred);
                         // transfer all projection values from the new_var into the existing var
                         let start_new = (defid_block, new_var, ProjectionVec::new());
                         let query_new = match new_var.0.checked_add(1) {
@@ -705,6 +728,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                 }
             } else {
                 // push the rval if no existing value
+                println!("No existing value");
                 self.add_value_with_projection(defid_block, varid, rval_value, projections)
             }
         }

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -607,7 +607,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
         projections: ProjectionVec,
     ) {
         // println!("In add val with proj: Adding new value defid - {:?} varid - {:?} proj vec - {:?} val - {:?}", defid_block, varid, projections, value);
-        println!("Add val with projection: {:?}", value);
+        // println!("Add val with projection: {:?}", value);
         let (varid, projections) = self.get_farthest_obj(defid_block, varid, projections);
         self.value_manager
             .insert_var_with_projection(defid_block, varid, projections, value);
@@ -621,7 +621,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
     #[inline]
     pub fn add_value_to_definition(&mut self, defid_block: DefId, lval: Variable, rvalue: Rvalue) {
         // println!("Entered add val to def function with defid - {:?}, lval - {:?}, rval - {:?}", defid_block, lval, rvalue);
-        println!("Add val to def: {:?}", rvalue);
+        // println!("Add val to def: {:?}", rvalue);
         if let Variable {
             base: Base::Var(varid),
             projections,
@@ -633,7 +633,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                 .get_value(defid_block, varid, Some(projections.clone()))
                 .cloned()
             {
-                println!("The existing value: {:?}", existing_lval);
+                // println!("The existing value: {:?}", existing_lval);
                 // println!("The (current) real value: {:?}", rval_value);
                 // if there is an existing value...
                 match (existing_lval, rval_value) {
@@ -653,7 +653,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                     // SW: NEED TO MODIFY THIS CASE TO HANDLE REASSIGNMENTS. Hits if we do a reassignment after already having done one.
                     (Value::Const(const_value), Value::Phi(phi_value))
                     | (Value::Phi(phi_value), Value::Const(const_value)) => {
-                        println!("Entered constant and phi vec match case");
+                        // println!("Entered constant and phi vec match case");
                         let mut new_phi = phi_value;
                         new_phi.push(const_value);
                         self.add_value_with_projection(
@@ -672,7 +672,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                             Value::Phi(vec![const_value1, const_value2]),
                             projections,
                         );
-                        println!("Entered double constant match case");
+                        // println!("Entered double constant match case");
                     }
                     (Value::Object(exist_var), Value::Object(new_var)) => {
                         // store projection values that are transferred
@@ -728,7 +728,7 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                 }
             } else {
                 // push the rval if no existing value
-                println!("No existing value");
+                // println!("No existing value");
                 self.add_value_with_projection(defid_block, varid, rval_value, projections)
             }
         }

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -644,14 +644,13 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
                         )
                     }
                     // push consts into vec if both are consts
-                    (Value::Const(const_value1), Value::Const(const_value2)) => {
-                        self.add_value_with_projection(
+                    (Value::Const(const_value1), Value::Const(const_value2)) => self
+                        .add_value_with_projection(
                             defid_block,
                             varid,
                             Value::Phi(vec![const_value1, const_value2]),
                             projections,
-                        );
-                    }
+                        ),
                     (Value::Object(exist_var), Value::Object(new_var)) => {
                         // store projection values that are transferred
                         let mut projections_transferred = vec![];

--- a/crates/forge_analyzer/src/ir.rs
+++ b/crates/forge_analyzer/src/ir.rs
@@ -16,14 +16,11 @@ use std::slice;
 
 use forge_utils::create_newtype;
 use forge_utils::FxHashMap;
-use itertools::Itertools;
 use smallvec::smallvec;
 use smallvec::smallvec_inline;
 use smallvec::SmallVec;
-use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast;
 use swc_core::ecma::ast::BinaryOp;
-use swc_core::ecma::ast::Bool;
 use swc_core::ecma::ast::JSXText;
 use swc_core::ecma::ast::Lit;
 use swc_core::ecma::ast::Null;
@@ -140,7 +137,7 @@ pub struct Body {
     pub blocks: TiVec<BasicBlockId, BasicBlock>,
     pub vars: TiVec<VarId, VarKind>,
     pub values: FxHashMap<DefId, Value>,
-    pub ident_to_local: FxHashMap<Id, VarId>,
+    ident_to_local: FxHashMap<Id, VarId>,
     pub def_id_to_vars: FxHashMap<DefId, VarId>,
     pub class_instantiations: HashMap<DefId, DefId>,
     predecessors: OnceCell<TiVec<BasicBlockId, SmallVec<[BasicBlockId; 2]>>>,
@@ -342,12 +339,6 @@ impl Body {
     #[inline]
     pub(crate) fn add_var(&mut self, kind: VarKind) -> VarId {
         self.vars.push_and_get_key(kind)
-    }
-
-    #[inline]
-    pub(crate) fn add_insts(&mut self, new_insts: Vec<Inst>, bb: BasicBlockId) {
-        let block = self.blocks.get_mut(bb).unwrap();
-        block.insts = new_insts;
     }
 
     #[inline]

--- a/crates/forge_analyzer/src/ir.rs
+++ b/crates/forge_analyzer/src/ir.rs
@@ -342,6 +342,12 @@ impl Body {
     }
 
     #[inline]
+    pub(crate) fn add_insts(&mut self, new_insts: Vec<Inst>, bb: BasicBlockId) {
+        let block = self.blocks.get_mut(bb).unwrap();
+        block.insts = new_insts;
+    }
+
+    #[inline]
     pub(crate) fn get_defid_from_var(&self, varid: VarId) -> Option<DefId> {
         match self.vars.get(varid)? {
             VarKind::AnonClosure(def)
@@ -367,12 +373,20 @@ impl Body {
         var_id
     }
 
+    // This function returns the varId that maps to the input defId,
+    //      or creates a new mapping of type global reference with the input defId and new varId.
     #[inline]
     pub(crate) fn get_or_insert_global(&mut self, def: DefId) -> VarId {
         *self
             .def_id_to_vars
             .entry(def)
             .or_insert_with(|| self.vars.push_and_get_key(VarKind::GlobalRef(def)))
+    }
+
+    // This function updates the existing DefId -> VarId mapping with the input values, or inserts new if one doesn't exist.
+    #[inline]
+    pub(crate) fn update_global(&mut self, def: DefId, var: VarId) {
+        self.def_id_to_vars.insert(def, var);
     }
 
     #[inline]

--- a/test-apps/basic/package.json
+++ b/test-apps/basic/package.json
@@ -8,12 +8,10 @@
     "validate": "tsc --noEmit --project ./tsconfig.json"
   },
   "devDependencies": {
-    "@types/node": "20.11.20",
+    "@forge/api": "^3.8.0",
+    "@forge/ui": "^1.11.1",
+    "@types/node": "^20.14.10",
     "@types/react": "18.2.57",
     "typescript": "5.3.3"
-  },
-  "dependencies": {
-    "@forge/api": "3.2.0",
-    "@forge/ui": "1.11.0"
   }
 }

--- a/test-apps/basic/package.json
+++ b/test-apps/basic/package.json
@@ -8,10 +8,12 @@
     "validate": "tsc --noEmit --project ./tsconfig.json"
   },
   "devDependencies": {
-    "@forge/api": "^3.8.0",
-    "@forge/ui": "^1.11.1",
-    "@types/node": "^20.14.10",
+    "@types/node": "20.11.20",
     "@types/react": "18.2.57",
     "typescript": "5.3.3"
+  },
+  "dependencies": {
+    "@forge/api": "3.2.0",
+    "@forge/ui": "1.11.0"
   }
 }

--- a/test-apps/basic/src/index.tsx
+++ b/test-apps/basic/src/index.tsx
@@ -13,6 +13,11 @@ let test_function = (word) => {
   let test_var = "test_var";
 }
 
+function test_bug() {
+  let b = 3;
+  let a = b
+}
+
 function complex(a) {
   let b = a - 20;
   let c = b + 1;

--- a/test-apps/basic/src/index.tsx
+++ b/test-apps/basic/src/index.tsx
@@ -42,7 +42,6 @@ function var_reref() {
   c = 2 * b;
 }
 
-
 const App = () => {
 
     let testObjectOther = {
@@ -58,6 +57,15 @@ const App = () => {
       return res;
     }
   }
+
+    let value = "value"
+
+    let h = { headers: { authorization: "test" } }
+    h.headers.authorization = process.env.SECRET
+    h.headers.authorization = `test ${value}`
+
+
+    fetch("url", h)
 
   foo();
   test_function("test_word");

--- a/test-apps/basic/src/index.tsx
+++ b/test-apps/basic/src/index.tsx
@@ -33,6 +33,16 @@ function reassign() {
   b = "7" + a;
 }
 
+function var_reref() {
+  let a = 4;
+  let b = 7;
+  a = 10;
+  let c = a + b
+  a = 5;
+  c = 2 * b;
+}
+
+
 const App = () => {
 
     let testObjectOther = {

--- a/test-apps/basic/src/index.tsx
+++ b/test-apps/basic/src/index.tsx
@@ -13,6 +13,26 @@ let test_function = (word) => {
   let test_var = "test_var";
 }
 
+function complex(a) {
+  let b = a - 20;
+  let c = b + 1;
+  b = 10;
+  return b * 10;
+}
+
+function simple() {
+  let a = 4;
+  let b = 7;
+  a = 10;
+  a = 5;
+}
+
+function reassign() {
+  let a = 4;
+  let b = "7";
+  b = "7" + a;
+}
+
 const App = () => {
 
     let testObjectOther = {
@@ -28,15 +48,6 @@ const App = () => {
       return res;
     }
   }
-
-    let value = "value"
-
-    let h = { headers: { authorization: "test" } }
-    h.headers.authorization = process.env.SECRET
-    h.headers.authorization = `test ${value}`
-
-
-    fetch("url", h)
 
   foo();
   test_function("test_word");


### PR DESCRIPTION
FSRT should be in “static single assignment form”, i.e. there should be exactly one definition of each variable, as this simplifies later analysis. This PR fixes this bug, and ensures that every variable has one definition.

More on the bug: Take this code example below:

```
function foo(a) {
  let b = a - 20;
  let c = b + 1;
  b = 10;
  return b * 10;
}
```
The above function currently gives this IR:

```
Variables:
%0: return value
%1: local definition of b
%2: local definition of c
%3: local definition of b
%4: local definition of b
%5: global ref to a
%6: temporary
%7: global ref to b
%8: temporary
%9: global ref to c
%10: temporary
bb0:
    %6 = %5 - 20
    %7 = %6 
    %8 = %7 + 1
    %9 = %8
    %7 = 10 // second assignment of %7
    _ = 10
    %10 = %7 * 10
    %0 = %10
    return
```
Note that in the current output of our IR that every “use” of the variable %7 only needs to consider the definition of “%7 = 10”. Thus, we can replace the assignment “%7 = 10” with “%11 = 10” and all following uses of “%7” with the new variable “%11”. 