### PR TITLE
ggladstone/eas 4431

### DIFF
--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -96,12 +96,15 @@ pub struct Consumer<'a> {
 }
 
 // Trigger Modules
+// https://developer.atlassian.com/platform/forge/manifest-reference/modules/scheduled-trigger/
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum Interval {
     Hour,
     Day,
     Week,
+    #[serde(rename = "fiveMinute")]
+    FiveMinute,
 }
 
 // Maps to Scheduled Trigger under Common Modules

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -87,11 +87,14 @@ pub struct FunctionMod<'a> {
     pub providers: Option<AuthProviders<'a>>,
 }
 
+// https://developer.atlassian.com/platform/forge/manifest-reference/modules/consumer/
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Consumer<'a> {
     key: &'a str,
     queue: &'a str,
-    #[serde(borrow)]
+    #[serde(default, borrow)]
+    pub function: Option<&'a str>,
+    #[serde(default, borrow)]
     pub resolver: Resolver<'a>,
 }
 
@@ -681,7 +684,7 @@ impl<'a> ForgeModules<'a> {
         let Self {
             mut webtriggers,
             custom_field,
-            consumers: _,
+            consumers,
             functions,
             event_triggers: _,
             scheduled_triggers: _,
@@ -736,6 +739,11 @@ impl<'a> ForgeModules<'a> {
         // for all trigger things
 
         let mut invokable_functions = BTreeSet::new();
+
+        for consumer in consumers {
+            invokable_functions.extend(consumer.function);
+            invokable_functions.extend(consumer.resolver.function);
+        }
 
         // Compass Module Functions
         compass_admin_page.append_functions(&mut invokable_functions);
@@ -1306,6 +1314,37 @@ mod tests {
         assert_eq!(action.key, "indexing-compass");
         assert_eq!(action.function, Some("compass-fn"));
         assert_eq!(action.endpoint, None);
+    }
+
+    #[test]
+    fn test_consumer_direct_function_deserializes_and_is_invokable() {
+        let yaml = r#"
+    app:
+    id: my-app
+    modules:
+    function:
+        - key: functionHandler
+        handler: jqlFunctions/functionProcessor.handleFunction
+    consumer:
+        - key: my-queue-consumer
+        queue: my-queue
+        function: functionHandler
+    permissions:
+    scopes:
+        - read:jira-work
+    "#;
+
+        let manifest: ForgeManifest<'_> = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(manifest.modules.consumers.len(), 1);
+        assert_eq!(
+            manifest.modules.consumers[0].function,
+            Some("functionHandler")
+        );
+
+        let entrypoints: Vec<_> = manifest.modules.into_analyzable_functions().collect();
+        assert_eq!(entrypoints.len(), 1);
+        assert!(entrypoints[0].invokable);
+        assert_eq!(entrypoints[0].function.key, "functionHandler");
     }
 
     // Test to check if hardcoded secrets are detected properly in OAuth2 Provider

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -775,11 +775,6 @@ impl<'a> ForgeModules<'a> {
 
         let mut invokable_functions = BTreeSet::new();
 
-        for consumer in consumers {
-            invokable_functions.extend(consumer.function);
-            invokable_functions.extend(consumer.resolver.function);
-        }
-
         // Compass Module Functions
         compass_admin_page.append_functions(&mut invokable_functions);
 

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -113,8 +113,11 @@ enum Interval {
 // Maps to Scheduled Trigger under Common Modules
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 struct ScheduledTrigger<'a> {
-    #[serde(flatten, borrow)]
-    raw: RawTrigger<'a>,
+    key: &'a str,
+    #[serde(default, borrow)]
+    function: Option<&'a str>,
+    #[serde(default, borrow)]
+    endpoint: Option<&'a str>,
     interval: Interval,
 }
 

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -1369,37 +1369,6 @@ permissions:
         );
     }
 
-    #[test]
-    fn test_consumer_direct_function_deserializes_and_is_invokable() {
-        let yaml = r#"
-app:
-  id: my-app
-modules:
-  function:
-    - key: functionHandler
-      handler: jqlFunctions/functionProcessor.handleFunction
-  consumer:
-    - key: my-queue-consumer
-      queue: my-queue
-      function: functionHandler
-permissions:
-  scopes:
-    - read:jira-work
-"#;
-
-        let manifest: ForgeManifest<'_> = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(manifest.modules.consumers.len(), 1);
-        assert_eq!(
-            manifest.modules.consumers[0].function,
-            Some("functionHandler")
-        );
-
-        let entrypoints: Vec<_> = manifest.modules.into_analyzable_functions().collect();
-        assert_eq!(entrypoints.len(), 1);
-        assert!(entrypoints[0].invokable);
-        assert_eq!(entrypoints[0].function.key, "functionHandler");
-    }
-
     // Test to check if hardcoded secrets are detected properly in OAuth2 Provider
     #[test]
     fn test_oauth_provider_hardcoded_secrets() {

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::Error;
 use forge_utils::FxHashMap;
 use itertools::Itertools;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_yaml::Value;
 use tracing::trace;
 
@@ -428,10 +428,42 @@ pub struct Content<'a> {
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Perms<'a> {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_scopes")]
     pub scopes: Vec<String>,
     #[serde(default, borrow)]
     content: Content<'a>,
+}
+
+fn deserialize_scopes<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+
+    match value {
+        Value::Null => Ok(vec![]),
+        Value::Sequence(scopes) => scopes
+            .into_iter()
+            .map(|scope| match scope {
+                Value::String(scope) => Ok(scope),
+                other => Err(serde::de::Error::custom(format!(
+                    "expected scope string, got {other:?}"
+                ))),
+            })
+            .collect(),
+        Value::Mapping(scopes) => scopes
+            .into_iter()
+            .map(|(scope, _)| match scope {
+                Value::String(scope) => Ok(scope),
+                other => Err(serde::de::Error::custom(format!(
+                    "expected scope key string, got {other:?}"
+                ))),
+            })
+            .collect(),
+        other => Err(serde::de::Error::custom(format!(
+            "expected scopes sequence or mapping, got {other:?}"
+        ))),
+    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -1320,22 +1352,45 @@ mod tests {
     }
 
     #[test]
+    fn test_permission_scopes_deserialize_from_mapping() {
+        let yaml = r#"
+app:
+  id: my-app
+modules:
+  function:
+    - key: functionHandler
+      handler: jqlFunctions/functionProcessor.handleFunction
+permissions:
+  scopes:
+    read:jira-work: &id001
+      allowImpersonation: true
+    write:jira-work: *id001
+"#;
+
+        let manifest: ForgeManifest<'_> = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            manifest.permissions.scopes,
+            vec!["read:jira-work".to_string(), "write:jira-work".to_string()]
+        );
+    }
+
+    #[test]
     fn test_consumer_direct_function_deserializes_and_is_invokable() {
         let yaml = r#"
-    app:
-    id: my-app
-    modules:
-    function:
-        - key: functionHandler
-        handler: jqlFunctions/functionProcessor.handleFunction
-    consumer:
-        - key: my-queue-consumer
-        queue: my-queue
-        function: functionHandler
-    permissions:
-    scopes:
-        - read:jira-work
-    "#;
+app:
+  id: my-app
+modules:
+  function:
+    - key: functionHandler
+      handler: jqlFunctions/functionProcessor.handleFunction
+  consumer:
+    - key: my-queue-consumer
+      queue: my-queue
+      function: functionHandler
+permissions:
+  scopes:
+    - read:jira-work
+"#;
 
         let manifest: ForgeManifest<'_> = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(manifest.modules.consumers.len(), 1);


### PR DESCRIPTION
### Fix four manifest parsing gaps causing silent zero-finding scans

Tracked in GitHub issue #87 / EAS-4431.

**Changes**
Bug-1 - Consumer function: reference
consumer modules now accept a direct function: field. Previously, Consumer required a resolver, so direct function consumers failed deserialization silently.

Bug-2 - fiveMinute scheduled trigger interval
Adds explicit serde rename for Forge's camelCase fiveMinute interval. The enum's rename_all = "lowercase" would deserialize it as fiveminute, not fiveMinute.

Bug-3 - Scheduled trigger endpoint: routing
scheduledTrigger now accepts endpoint-routed triggers without a function: field. Previously it reused RawTrigger which required function.

Bug-4 - Mapping-style permissions.scopes
permissions.scopes now accepts both sequence and mapping forms. Mapping keys are normalized to scope names, values discarded. Null/bare scopes: continues to deserialize as an empty list.

**Why this matters**
FSRT silently falls back to ForgeManifest::default() on a parse error, scans nothing, and exits cleanly. A real vulnerability is missed with no warning.

**Next Step Actions Needed**
Need to log when FSRT fails so we can update syntax support.

eg. Log manifest parse failures and set errors: true in JSON output so unsupported Forge manifest shapes are observable.