### PR TITLE
Ggladstone/release yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       tag_name:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test workspace
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Run tests
+        run: cargo test --workspace --locked
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: test
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            binary: fsrt
+            archive: fsrt-linux-x86_64.tar.gz
+
+          - name: macos-aarch64
+            os: macos-latest
+            binary: fsrt
+            archive: fsrt-macos-aarch64.tar.gz
+
+          - name: windows-x86_64
+            os: windows-latest
+            binary: fsrt.exe
+            archive: fsrt-windows-x86_64.zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Build fsrt
+        run: cargo build --release --locked -p fsrt
+
+      - name: Package Unix binary
+        if: runner.os != 'Windows'
+        run: |
+          mkdir dist
+          cp "target/release/${{ matrix.binary }}" dist/
+          cp README.md LICENSE-APACHE LICENSE-MIT dist/
+          tar -czf "${{ matrix.archive }}" -C dist .
+
+      - name: Package Windows binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path dist
+          Copy-Item "target/release/${{ matrix.binary }}" dist/
+          Copy-Item README.md, LICENSE-APACHE, LICENSE-MIT dist/
+          Compress-Archive -Path dist/* -DestinationPath "${{ matrix.archive }}"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ matrix.archive }}
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download packaged binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" artifacts/* \
+            --title "FSRT ${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing release tag to rebuild and publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -44,6 +51,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -74,6 +83,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
 
       - name: Download packaged binaries
         uses: actions/download-artifact@v8
@@ -82,8 +93,10 @@ jobs:
           merge-multiple: true
 
       - name: Package source code
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
         run: |
-          safe_ref_name="${GITHUB_REF_NAME//\//-}"
+          safe_ref_name="${RELEASE_TAG//\//-}"
           git archive \
             --format=zip \
             --prefix="fsrt-${safe_ref_name}/" \
@@ -95,11 +108,15 @@ jobs:
             -o "artifacts/fsrt-${safe_ref_name}-source.tar.gz" \
             HEAD
 
-      - name: Create release
+      - name: Publish release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" artifacts/* \
-            --title "FSRT ${{ github.ref_name }}" \
-            --generate-notes \
-            --verify-tag
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" \
+              --title "FSRT $RELEASE_TAG" \
+              --generate-notes \
+              --verify-tag
+
+          gh release upload "$RELEASE_TAG" artifacts/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
             os: ubuntu-latest                       # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
             archive: fsrt-linux-x86_64.tar.gz
 
-          - name: macos-x86_64
-            os: macos-15-intel
-            archive: fsrt-macos-x86_64.tar.gz
+          # - name: macos-x86_64
+          #   os: macos-15-intel
+          #   archive: fsrt-macos-x86_64.tar.gz
 
           - name: macos-aarch64
             os: macos-latest
@@ -48,12 +48,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build fsrt
-        run: cargo build --release --locked -p fsrt
+        run: cargo build --profile dist --locked -p fsrt
 
       - name: Package binary
         run: |
           mkdir dist
-          cp target/release/fsrt dist/
+          cp target/dist/fsrt dist/
           cp README.md LICENSE-APACHE LICENSE-MIT dist/
           tar -czf "${{ matrix.archive }}" -C dist .
 
@@ -83,15 +83,16 @@ jobs:
 
       - name: Package source code
         run: |
+          safe_ref_name="${GITHUB_REF_NAME//\//-}"
           git archive \
             --format=zip \
-            --prefix="fsrt-${{ github.ref_name }}/" \
-            -o "artifacts/fsrt-${{ github.ref_name }}-source.zip" \
+            --prefix="fsrt-${safe_ref_name}/" \
+            -o "artifacts/fsrt-${safe_ref_name}-source.zip" \
             HEAD
           git archive \
             --format=tar.gz \
-            --prefix="fsrt-${{ github.ref_name }}/" \
-            -o "artifacts/fsrt-${{ github.ref_name }}-source.tar.gz" \
+            --prefix="fsrt-${safe_ref_name}/" \
+            -o "artifacts/fsrt-${safe_ref_name}-source.tar.gz" \
             HEAD
 
       - name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test workspace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -32,46 +32,33 @@ jobs:
         include:
           - name: linux-x86_64
             os: ubuntu-latest
-            binary: fsrt
             archive: fsrt-linux-x86_64.tar.gz
 
+          - name: macos-x86_64
+            os: macos-13
+            archive: fsrt-macos-x86_64.tar.gz
+
           - name: macos-aarch64
-            os: macos-latest
-            binary: fsrt
+            os: macos-14
             archive: fsrt-macos-aarch64.tar.gz
 
-          - name: windows-x86_64
-            os: windows-latest
-            binary: fsrt.exe
-            archive: fsrt-windows-x86_64.zip
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build fsrt
         run: cargo build --release --locked -p fsrt
 
-      - name: Package Unix binary
-        if: runner.os != 'Windows'
+      - name: Package binary
         run: |
           mkdir dist
-          cp "target/release/${{ matrix.binary }}" dist/
+          cp target/release/fsrt dist/
           cp README.md LICENSE-APACHE LICENSE-MIT dist/
           tar -czf "${{ matrix.archive }}" -C dist .
 
-      - name: Package Windows binary
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Path dist
-          Copy-Item "target/release/${{ matrix.binary }}" dist/
-          Copy-Item README.md, LICENSE-APACHE, LICENSE-MIT dist/
-          Compress-Archive -Path dist/* -DestinationPath "${{ matrix.archive }}"
-
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.archive }}
           path: ${{ matrix.archive }}
@@ -86,10 +73,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download packaged binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Existing release tag to rebuild and publish
+        description: Existing release tag to rebuild and publish (eg. v*.*.*)
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
             gh release create "$RELEASE_TAG" \
               --title "FSRT $RELEASE_TAG" \
               --generate-notes \
-              --verify-tag
+              --verify-tag \
+              --draft
 
           gh release upload "$RELEASE_TAG" artifacts/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,15 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            os: ubuntu-latest                       # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
             archive: fsrt-linux-x86_64.tar.gz
 
           - name: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             archive: fsrt-macos-x86_64.tar.gz
 
           - name: macos-aarch64
-            os: macos-14
+            os: macos-latest
             archive: fsrt-macos-aarch64.tar.gz
 
     steps:
@@ -80,6 +80,19 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Package source code
+        run: |
+          git archive \
+            --format=zip \
+            --prefix="fsrt-${{ github.ref_name }}/" \
+            -o "artifacts/fsrt-${{ github.ref_name }}-source.zip" \
+            HEAD
+          git archive \
+            --format=tar.gz \
+            --prefix="fsrt-${{ github.ref_name }}/" \
+            -o "artifacts/fsrt-${{ github.ref_name }}-source.tar.gz" \
+            HEAD
 
       - name: Create release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,22 +92,6 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Package source code
-        env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
-        run: |
-          safe_ref_name="${RELEASE_TAG//\//-}"
-          git archive \
-            --format=zip \
-            --prefix="fsrt-${safe_ref_name}/" \
-            -o "artifacts/fsrt-${safe_ref_name}-source.zip" \
-            HEAD
-          git archive \
-            --format=tar.gz \
-            --prefix="fsrt-${safe_ref_name}/" \
-            -o "artifacts/fsrt-${safe_ref_name}-source.tar.gz" \
-            HEAD
-
       - name: Publish release assets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,10 @@ too_many_arguments = "allow"
 # enable full optimization for dependencies
 [profile.dev.package."*"]
 opt-level = 3
+
+[profile.dist]
+inherits = "release"
+strip = true
+lto = true
+codegen-units = 1
+opt-level = 3


### PR DESCRIPTION
Summary
Adds a GitHub Actions release pipeline for FSRT and a release-only Cargo dist profile for smaller published binaries.

Changes
• Added release workflow for tagged v*.. releases
• Supports manual rebuilds via workflow_dispatch with an existing tag_name
• Builds and packages Linux/macOS FSRT binaries
• Publishes/replaces release assets with gh release upload --clobber
• Adds [profile.dist] with stripping, LTO, and single codegen unit

Testing
• Release workflow intended to run on version tags and manual dispatch using an existing tag
• Existing workspace tests run in the release workflow before publishing

Test: Checkout releases [ggladstone/fsrt](https://github.com/gladstone-9/FSRT/releases)

Related: EAS-4428