### PR TITLE
Mint FCT and FIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Local secrets for the mint-fct/mint-fit remote commands — never commit these.
+session-cookie.txt
+api-token.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 /target
-
-# Local secrets for the mint-fct/mint-fit remote commands — never commit these.
-session-cookie.txt
-api-token.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0faa974509d38b33ff89282db9c3295707ccf031727c0de9772038ec526852ba"
+dependencies = [
+ "pathdiff",
+ "serde",
+ "toml",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +726,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tracing",
- "ureq",
+ "ureq 3.0.11",
 ]
 
 [[package]]
@@ -749,7 +761,9 @@ dependencies = [
 name = "fsrt"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "clap",
+ "config",
  "forge_analyzer",
  "forge_file_resolver",
  "forge_loader",
@@ -762,9 +776,11 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "swc_core",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
+ "ureq 2.12.1",
  "walkdir",
 ]
 
@@ -1839,6 +1855,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
  "serde",
 ]
 
@@ -3162,6 +3187,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,6 +3368,24 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots",
+]
 
 [[package]]
 name = "ureq"
@@ -3694,6 +3768,21 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+config = { version = "0.15", default-features = false, features = ["toml"] }
 itertools = "0.14.0"
 num-bigint = { version = "0.4.4" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ Arguments:
     --graphql-schema-path <LOCATION>        Uses the graphql schema in location; othwerwise selects ~/.config dir  
 ```
 
+## Minting Forge tokens
+
+In addition to static scanning, FSRT can mint Forge tokens against a live
+Atlassian site — useful for dynamic testing of a Forge app's backend.
+
+- **`mint-fct`** — mint a **Forge Context Token (FCT)**.
+- **`mint-fit`** — mint a **Forge Invocation Token (FIT)**. Internally mints an
+  FCT first, then exchanges it for a FIT.
+
+Both commands read a shared TOML config (default: `./fsrt-remote.toml`) and the
+target app's `manifest.yml`. See [`fsrt-remote.toml`](fsrt-remote.toml) for a
+fully commented example — copy it and replace the placeholder values with your
+own. It selects the product (`confluence` or `global`), the GraphQL endpoint,
+and how to authenticate (a raw session cookie or a Basic API token).
+
+> **Warning:** these commands send and print auth material (cookies/tokens).
+> Never commit real cookies, API tokens, tenant IDs, or account emails.
+
+```sh
+# Mint a Forge Context Token for the app in the current directory.
+fsrt mint-fct --app-dir . --config ./fsrt-remote.toml
+
+# Preview the exact GraphQL request without sending it.
+fsrt mint-fct --config ./fsrt-remote.toml --dry-run
+
+# Mint a Forge Invocation Token (mints an FCT under the hood first).
+fsrt mint-fit --app-dir . --config ./fsrt-remote.toml
+```
+
+Both `--app-dir` (default `.`) and `--config` (default `./fsrt-remote.toml`)
+are optional. Use `--dry-run` to render and inspect the request without calling
+the GraphQL gateway.
+
 ## Installation
 
 You will need to install [Rust] to compile `FSRT`. You can install `Rust` through [Rustup] or through your distro's package manager. You will also

--- a/README.md
+++ b/README.md
@@ -27,38 +27,17 @@ Arguments:
     --graphql-schema-path <LOCATION>        Uses the graphql schema in location; othwerwise selects ~/.config dir  
 ```
 
-## Minting Forge tokens
+### Commands
 
-In addition to static scanning, FSRT can mint Forge tokens against a live
-Atlassian site — useful for dynamic testing of a Forge app's backend.
-
-- **`mint-fct`** — mint a **Forge Context Token (FCT)**.
-- **`mint-fit`** — mint a **Forge Invocation Token (FIT)**. Internally mints an
-  FCT first, then exchanges it for a FIT.
-
-Both commands read a shared TOML config (default: `./fsrt-remote.toml`) and the
-target app's `manifest.yml`. See [`fsrt-remote.toml`](fsrt-remote.toml) for a
-fully commented example — copy it and replace the placeholder values with your
-own. It selects the product (`confluence` or `global`), the GraphQL endpoint,
-and how to authenticate (a raw session cookie or a Basic API token).
-
-> **Warning:** these commands send and print auth material (cookies/tokens).
-> Never commit real cookies, API tokens, tenant IDs, or account emails.
-
-```sh
-# Mint a Forge Context Token for the app in the current directory.
-fsrt mint-fct --app-dir . --config ./fsrt-remote.toml
-
-# Preview the exact GraphQL request without sending it.
-fsrt mint-fct --config ./fsrt-remote.toml --dry-run
-
-# Mint a Forge Invocation Token (mints an FCT under the hood first).
-fsrt mint-fit --app-dir . --config ./fsrt-remote.toml
+```text
+mint-fct    Mint a Forge Context Token (FCT)
+mint-fit    Mint a Forge Invocation Token (FIT)
 ```
 
-Both `--app-dir` (default `.`) and `--config` (default `./fsrt-remote.toml`)
-are optional. Use `--dry-run` to render and inspect the request without calling
-the GraphQL gateway.
+For dynamic testing, `mint-fct` and `mint-fit` mint Forge tokens against a live
+Atlassian site. They read a TOML config (default `./fsrt-remote.toml`); see
+[`fsrt-remote.toml`](fsrt-remote.toml) for a commented example. Run with
+`--help` for options.
 
 ## Installation
 

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -47,6 +47,26 @@ impl<'a> HasFunctions<'a> for CommonKey<'a> {
     }
 }
 
+impl<'a> CommonKey<'a> {
+    /// The backend resolver function this module invokes, if any.
+    ///
+    /// Prefers the top-level `function` shorthand, then falls back to
+    /// `resolver.function`. Modules wired to a `resolver.endpoint` (a Forge
+    /// Remote endpoint rather than a Forge-hosted resolver) have no function and
+    /// return `None`.
+    fn resolver_function(&self) -> Option<&'a str> {
+        self.function
+            .or_else(|| self.resolver.and_then(|r| r.function))
+    }
+}
+
+impl<'a> MacroMod<'a> {
+    /// The backend resolver function this macro invokes, if any.
+    fn resolver_function(&self) -> Option<&'a str> {
+        self.common_keys.resolver_function()
+    }
+}
+
 impl<'a> HasFunctions<'a> for JustFunc<'a> {
     fn append_functions<I: Extend<&'a str>>(&self, funcs: &mut I) {
         funcs.extend(self.function);
@@ -495,6 +515,8 @@ where
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Remotes {
+    #[serde(default)]
+    pub key: String,
     #[serde(default)]
     pub auth: Value,
 }
@@ -972,6 +994,157 @@ impl<'a> ForgeModules<'a> {
     }
 }
 
+// Number of module types the FCT auto-detectors scan (see
+// `preferred_fct_modules_with_functions`).
+const FCT_MODULE_TYPE_COUNT: usize = 6;
+
+// One entry per FCT-targetable module type: (module type string, keys declared
+// for that type).
+type FctModuleKeys<'a> = [(&'static str, Vec<&'a str>); FCT_MODULE_TYPE_COUNT];
+
+// Like `FctModuleKeys`, but each key is paired with the resolver function that
+// module invokes (or `None` for endpoint-backed modules).
+type FctModuleKeysWithFns<'a> =
+    [(&'static str, Vec<(&'a str, Option<&'a str>)>); FCT_MODULE_TYPE_COUNT];
+
+impl<'a> ForgeModules<'a> {
+    // The module types the Forge Context Token minting flow can target, in
+    // preferred auto-detection order. Each tuple is
+    // (manifest module type string used in the FCT ARI, accessor returning the
+    // keys declared for that module type).
+    //
+    // Keeping this list here (rather than in the mint code) means module/remote
+    // knowledge lives entirely in forge_loader, and callers work off the typed
+    // manifest instead of re-walking raw YAML.
+    //
+    // This is a keys-only projection of `preferred_fct_modules_with_functions`
+    // so there is a SINGLE source of truth for the module list and its order.
+    // Adding a module type in one place can no longer desync the two
+    // auto-detectors (a mismatch there is exactly what causes the wrong
+    // `moduleKey` to be chosen).
+    fn preferred_fct_modules(&self) -> FctModuleKeys<'a> {
+        self.preferred_fct_modules_with_functions()
+            .map(|(module_type, entries)| {
+                (
+                    module_type,
+                    entries.into_iter().map(|(key, _fn)| key).collect(),
+                )
+            })
+    }
+
+    // The SINGLE source of truth for the module types the Forge Context Token
+    // minting flow can target, in preferred auto-detection order. Each entry is
+    // (manifest module type string used in the FCT ARI, list of
+    // (module key, backend resolver function the module invokes if any)).
+    //
+    // `preferred_fct_modules` is a keys-only projection of this. Used to resolve
+    // a module from a caller-supplied `--function` name so the selected module
+    // actually owns the resolver being invoked.
+    //
+    // Endpoint-backed modules (Forge Remote endpoints, not Forge-hosted
+    // resolvers) carry `None` and therefore never match a function name.
+    fn preferred_fct_modules_with_functions(&self) -> FctModuleKeysWithFns<'a> {
+        [
+            (
+                "macro",
+                self.macros
+                    .iter()
+                    .map(|m| (m.common_keys.key, m.resolver_function()))
+                    .collect(),
+            ),
+            (
+                "globalPage",
+                self.confluence_global_page
+                    .iter()
+                    .map(|m| (m.key, m.resolver_function()))
+                    .collect(),
+            ),
+            (
+                "spacePage",
+                self.space_page
+                    .iter()
+                    .map(|m| (m.key, m.resolver_function()))
+                    .collect(),
+            ),
+            (
+                "globalPage",
+                self.jira_global_page
+                    .iter()
+                    .map(|m| (m.key, m.resolver_function()))
+                    .collect(),
+            ),
+            (
+                "issuePanel",
+                self.issue_panel
+                    .iter()
+                    .map(|m| (m.key, m.resolver_function()))
+                    .collect(),
+            ),
+            (
+                "globalPage",
+                self.project_page
+                    .iter()
+                    .map(|m| (m.key, m.resolver_function()))
+                    .collect(),
+            ),
+        ]
+    }
+
+    /// Auto-detect a module to mint a Forge Context Token for.
+    ///
+    /// Returns the first `(module_key, module_type)` found by scanning the
+    /// supported module types in preferred order, or `None` if the manifest
+    /// declares none of them.
+    pub fn detect_fct_module(&self) -> Option<(&'a str, &'static str)> {
+        for (module_type, keys) in self.preferred_fct_modules() {
+            if let Some(key) = keys.into_iter().next() {
+                return Some((key, module_type));
+            }
+        }
+        None
+    }
+
+    /// Auto-detect the module that invokes a specific backend resolver
+    /// `function`.
+    ///
+    /// Scans the supported module types in preferred order and returns the first
+    /// `(module_key, module_type)` whose `resolver.function` (or `function`
+    /// shorthand) equals `function`. Returns `None` when no supported module is
+    /// wired to that function — e.g. the function is only reachable via a
+    /// web trigger, or the manifest declares only endpoint-backed modules.
+    ///
+    /// This is preferred over `detect_fct_module` when the caller knows which
+    /// function it is invoking: for apps where several modules share one
+    /// resolver, or where the first-declared module is endpoint-backed, blindly
+    /// taking the first module yields a `moduleKey` that does not match the
+    /// invoked resolver.
+    pub fn detect_fct_module_for_function(
+        &self,
+        function: &str,
+    ) -> Option<(&'a str, &'static str)> {
+        for (module_type, entries) in self.preferred_fct_modules_with_functions() {
+            for (key, resolver_fn) in entries {
+                if resolver_fn == Some(function) {
+                    return Some((key, module_type));
+                }
+            }
+        }
+        None
+    }
+
+    /// Look up the module type for a specific, caller-supplied module key.
+    ///
+    /// Returns `None` if no supported module declares that key.
+    pub fn fct_module_type_for_key(&self, key: &str) -> Option<&'static str> {
+        for (module_type, keys) in self.preferred_fct_modules() {
+            if keys.contains(&key) {
+                return Some(module_type);
+            }
+        }
+        None
+    }
+}
+
 impl<S> FunctionRef<'_, S> {
     const VALID_EXTS: [&'static str; 4] = ["jsx", "tsx", "ts", "js"];
 }
@@ -1125,6 +1298,73 @@ mod tests {
                 path: "src/my-function-handler".into(),
                 status: Unresolved,
             }
+        );
+    }
+
+    // Fixture shape (generic, not tied to any specific app): the first-declared
+    // macro is endpoint-backed, while two later macros share one resolver
+    // function. detect_fct_module (first module) picks the endpoint macro, but
+    // detect_fct_module_for_function must pick the macro that owns the resolver.
+    #[test]
+    fn test_detect_fct_module_for_function() {
+        let json = r#"{
+            "app": { "name": "Test App", "id": "test-app" },
+            "modules": {
+                "macro": [
+                    {
+                        "key": "endpoint-macro",
+                        "resolver": { "endpoint": "some-endpoint" }
+                    },
+                    {
+                        "key": "resolver-macro-a",
+                        "resolver": { "function": "shared-resolver" }
+                    },
+                    {
+                        "key": "resolver-macro-b",
+                        "resolver": { "function": "shared-resolver" }
+                    }
+                ]
+            }
+        }"#;
+        let manifest: ForgeManifest<'_> = serde_json::from_str(json).unwrap();
+
+        // Blind first-module detection picks the endpoint-backed macro.
+        assert_eq!(
+            manifest.modules.detect_fct_module(),
+            Some(("endpoint-macro", "macro"))
+        );
+
+        // Function-aware detection picks the first macro owning the resolver.
+        assert_eq!(
+            manifest
+                .modules
+                .detect_fct_module_for_function("shared-resolver"),
+            Some(("resolver-macro-a", "macro"))
+        );
+
+        // An unknown function matches nothing.
+        assert_eq!(
+            manifest.modules.detect_fct_module_for_function("nope"),
+            None
+        );
+    }
+
+    // The `function` shorthand (no `resolver` block) is also matchable.
+    #[test]
+    fn test_detect_fct_module_for_function_shorthand() {
+        let json = r#"{
+            "app": { "name": "Shorthand App", "id": "shorthand-app" },
+            "modules": {
+                "macro": [
+                    { "key": "first-macro", "function": "other-fn" },
+                    { "key": "second-macro", "function": "target-fn" }
+                ]
+            }
+        }"#;
+        let manifest: ForgeManifest<'_> = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            manifest.modules.detect_fct_module_for_function("target-fn"),
+            Some(("second-macro", "macro"))
         );
     }
 

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -48,12 +48,6 @@ impl<'a> HasFunctions<'a> for CommonKey<'a> {
 }
 
 impl<'a> CommonKey<'a> {
-    /// The backend resolver function this module invokes, if any.
-    ///
-    /// Prefers the top-level `function` shorthand, then falls back to
-    /// `resolver.function`. Modules wired to a `resolver.endpoint` (a Forge
-    /// Remote endpoint rather than a Forge-hosted resolver) have no function and
-    /// return `None`.
     fn resolver_function(&self) -> Option<&'a str> {
         self.function
             .or_else(|| self.resolver.and_then(|r| r.function))
@@ -61,7 +55,6 @@ impl<'a> CommonKey<'a> {
 }
 
 impl<'a> MacroMod<'a> {
-    /// The backend resolver function this macro invokes, if any.
     fn resolver_function(&self) -> Option<&'a str> {
         self.common_keys.resolver_function()
     }
@@ -994,34 +987,18 @@ impl<'a> ForgeModules<'a> {
     }
 }
 
-// Number of module types the FCT auto-detectors scan (see
-// `preferred_fct_modules_with_functions`).
+// Number of module types the FCT auto-detectors scan.
 const FCT_MODULE_TYPE_COUNT: usize = 6;
 
-// One entry per FCT-targetable module type: (module type string, keys declared
-// for that type).
+// (module type string, keys declared for that type)
 type FctModuleKeys<'a> = [(&'static str, Vec<&'a str>); FCT_MODULE_TYPE_COUNT];
 
-// Like `FctModuleKeys`, but each key is paired with the resolver function that
-// module invokes (or `None` for endpoint-backed modules).
+// Like `FctModuleKeys`, but each key is paired with its resolver function.
 type FctModuleKeysWithFns<'a> =
     [(&'static str, Vec<(&'a str, Option<&'a str>)>); FCT_MODULE_TYPE_COUNT];
 
 impl<'a> ForgeModules<'a> {
-    // The module types the Forge Context Token minting flow can target, in
-    // preferred auto-detection order. Each tuple is
-    // (manifest module type string used in the FCT ARI, accessor returning the
-    // keys declared for that module type).
-    //
-    // Keeping this list here (rather than in the mint code) means module/remote
-    // knowledge lives entirely in forge_loader, and callers work off the typed
-    // manifest instead of re-walking raw YAML.
-    //
-    // This is a keys-only projection of `preferred_fct_modules_with_functions`
-    // so there is a SINGLE source of truth for the module list and its order.
-    // Adding a module type in one place can no longer desync the two
-    // auto-detectors (a mismatch there is exactly what causes the wrong
-    // `moduleKey` to be chosen).
+    // Keys-only projection of `preferred_fct_modules_with_functions`.
     fn preferred_fct_modules(&self) -> FctModuleKeys<'a> {
         self.preferred_fct_modules_with_functions()
             .map(|(module_type, entries)| {
@@ -1032,17 +1009,8 @@ impl<'a> ForgeModules<'a> {
             })
     }
 
-    // The SINGLE source of truth for the module types the Forge Context Token
-    // minting flow can target, in preferred auto-detection order. Each entry is
-    // (manifest module type string used in the FCT ARI, list of
-    // (module key, backend resolver function the module invokes if any)).
-    //
-    // `preferred_fct_modules` is a keys-only projection of this. Used to resolve
-    // a module from a caller-supplied `--function` name so the selected module
-    // actually owns the resolver being invoked.
-    //
-    // Endpoint-backed modules (Forge Remote endpoints, not Forge-hosted
-    // resolvers) carry `None` and therefore never match a function name.
+    // Source of truth for FCT-targetable module types, in preferred order.
+    // (module type string, list of (module key, resolver function if any))
     fn preferred_fct_modules_with_functions(&self) -> FctModuleKeysWithFns<'a> {
         [
             (
@@ -1090,11 +1058,7 @@ impl<'a> ForgeModules<'a> {
         ]
     }
 
-    /// Auto-detect a module to mint a Forge Context Token for.
-    ///
-    /// Returns the first `(module_key, module_type)` found by scanning the
-    /// supported module types in preferred order, or `None` if the manifest
-    /// declares none of them.
+    // First `(module_key, module_type)` in preferred order, or `None`.
     pub fn detect_fct_module(&self) -> Option<(&'a str, &'static str)> {
         for (module_type, keys) in self.preferred_fct_modules() {
             if let Some(key) = keys.into_iter().next() {
@@ -1104,37 +1068,7 @@ impl<'a> ForgeModules<'a> {
         None
     }
 
-    /// Auto-detect the module that invokes a specific backend resolver
-    /// `function`.
-    ///
-    /// Scans the supported module types in preferred order and returns the first
-    /// `(module_key, module_type)` whose `resolver.function` (or `function`
-    /// shorthand) equals `function`. Returns `None` when no supported module is
-    /// wired to that function — e.g. the function is only reachable via a
-    /// web trigger, or the manifest declares only endpoint-backed modules.
-    ///
-    /// This is preferred over `detect_fct_module` when the caller knows which
-    /// function it is invoking: for apps where several modules share one
-    /// resolver, or where the first-declared module is endpoint-backed, blindly
-    /// taking the first module yields a `moduleKey` that does not match the
-    /// invoked resolver.
-    pub fn detect_fct_module_for_function(
-        &self,
-        function: &str,
-    ) -> Option<(&'a str, &'static str)> {
-        for (module_type, entries) in self.preferred_fct_modules_with_functions() {
-            for (key, resolver_fn) in entries {
-                if resolver_fn == Some(function) {
-                    return Some((key, module_type));
-                }
-            }
-        }
-        None
-    }
-
-    /// Look up the module type for a specific, caller-supplied module key.
-    ///
-    /// Returns `None` if no supported module declares that key.
+    // Module type for a caller-supplied key, or `None`.
     pub fn fct_module_type_for_key(&self, key: &str) -> Option<&'static str> {
         for (module_type, keys) in self.preferred_fct_modules() {
             if keys.contains(&key) {
@@ -1301,12 +1235,8 @@ mod tests {
         );
     }
 
-    // Fixture shape (generic, not tied to any specific app): the first-declared
-    // macro is endpoint-backed, while two later macros share one resolver
-    // function. detect_fct_module (first module) picks the endpoint macro, but
-    // detect_fct_module_for_function must pick the macro that owns the resolver.
     #[test]
-    fn test_detect_fct_module_for_function() {
+    fn test_detect_fct_module() {
         let json = r#"{
             "app": { "name": "Test App", "id": "test-app" },
             "modules": {
@@ -1318,54 +1248,24 @@ mod tests {
                     {
                         "key": "resolver-macro-a",
                         "resolver": { "function": "shared-resolver" }
-                    },
-                    {
-                        "key": "resolver-macro-b",
-                        "resolver": { "function": "shared-resolver" }
                     }
                 ]
             }
         }"#;
         let manifest: ForgeManifest<'_> = serde_json::from_str(json).unwrap();
 
-        // Blind first-module detection picks the endpoint-backed macro.
+        // First-module detection picks the first declared macro.
         assert_eq!(
             manifest.modules.detect_fct_module(),
             Some(("endpoint-macro", "macro"))
         );
 
-        // Function-aware detection picks the first macro owning the resolver.
+        // Module type can be looked up by key.
         assert_eq!(
-            manifest
-                .modules
-                .detect_fct_module_for_function("shared-resolver"),
-            Some(("resolver-macro-a", "macro"))
+            manifest.modules.fct_module_type_for_key("resolver-macro-a"),
+            Some("macro")
         );
-
-        // An unknown function matches nothing.
-        assert_eq!(
-            manifest.modules.detect_fct_module_for_function("nope"),
-            None
-        );
-    }
-
-    // The `function` shorthand (no `resolver` block) is also matchable.
-    #[test]
-    fn test_detect_fct_module_for_function_shorthand() {
-        let json = r#"{
-            "app": { "name": "Shorthand App", "id": "shorthand-app" },
-            "modules": {
-                "macro": [
-                    { "key": "first-macro", "function": "other-fn" },
-                    { "key": "second-macro", "function": "target-fn" }
-                ]
-            }
-        }"#;
-        let manifest: ForgeManifest<'_> = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            manifest.modules.detect_fct_module_for_function("target-fn"),
-            Some(("second-macro", "macro"))
-        );
+        assert_eq!(manifest.modules.fct_module_type_for_key("nope"), None);
     }
 
     // Modified specific deserialization schemes for modules. Checking that new schemes can deserialize function values.

--- a/crates/fsrt/Cargo.toml
+++ b/crates/fsrt/Cargo.toml
@@ -15,6 +15,7 @@ graphql_schema = []
 
 [dependencies]
 clap.workspace = true
+config.workspace = true
 forge_analyzer.workspace = true
 forge_file_resolver.workspace = true
 forge_loader.workspace = true
@@ -31,3 +32,6 @@ walkdir.workspace = true
 graphql-parser = "0.4.0"
 glob = "0.3.2"
 regex.workspace = true
+ureq = { version = "2", features = ["json"] }
+thiserror.workspace = true
+base64 = "0.22"

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -56,11 +56,6 @@ use walkdir::WalkDir;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-// The top-level subcommand enum.
-// `#[derive(Subcommand)]` tells clap this is a set of mutually exclusive commands.
-// When the user runs `fsrt mint-fct ...`, clap fills in `Command::MintFct`.
-// When no subcommand is given, `command` is None and we fall through to the
-// existing scan behaviour — so nothing breaks for current users.
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Mint a Forge Context Token (FCT).
@@ -850,8 +845,6 @@ pub(crate) fn scan_directory<'a>(
     Ok(reporter.into_report())
 }
 
-// Print a subcommand error via Display (real newlines, no Debug wrapper) and
-// exit non-zero. On success, returns Ok(()) so main can propagate it normally.
 fn exit_on_err(result: Result<()>) -> Result<()> {
     if let Err(err) = result {
         eprintln!("Error: {err}");
@@ -862,19 +855,25 @@ fn exit_on_err(result: Result<()>) -> Result<()> {
 
 fn main() -> Result<()> {
     let mut args = Args::parse();
+
+    // `--verbose` on a mint subcommand raises the default log level to `info`
+    let verbose = matches!(
+        &args.command,
+        Some(Command::MintFct(a)) if a.verbose || a.dry_run
+    ) || matches!(
+        &args.command,
+        Some(Command::MintFit(a)) if a.verbose || a.dry_run
+    );
+    let env_filter = match EnvFilter::try_from_env("FORGE_LOG") {
+        Ok(filter) => filter,
+        Err(_) if verbose => EnvFilter::new("info"),
+        Err(_) => EnvFilter::new(""),
+    };
     tracing_subscriber::registry()
         .with(HierarchicalLayer::new(2))
-        .with(EnvFilter::from_env("FORGE_LOG"))
+        .with(env_filter)
         .init();
 
-    // Check if a subcommand was given.
-    // If the user ran `fsrt mint-fct ...`, route to run_mint_fct() and exit.
-    // If no subcommand was given, fall through to the existing scan behaviour —
-    // so `fsrt /path/to/app` keeps working exactly as before.
-    // Route to a subcommand if one was given. On error, print the message via
-    // Display (honours real newlines) and exit non-zero — rather than returning
-    // the error to main, which would Debug-print it (escaping `\n` and wrapping
-    // it in the error variant name, e.g. CookieExpired("...\n...")).
     if let Some(Command::MintFct(mint_fct_args)) = &args.command {
         return exit_on_err(mint_fct::run_mint_fct(mint_fct_args));
     }

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::type_complexity)]
 
 mod forge_project;
+mod mint_common;
+mod mint_fct;
+mod mint_fit;
 #[cfg(test)]
 mod test;
 
-use clap::{Parser, ValueHint};
+use clap::{Parser, Subcommand, ValueHint};
 use forge_permission_resolver::{
     permissions_cache::CacheConfig,
     permissions_resolver::{
@@ -53,9 +56,28 @@ use walkdir::WalkDir;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+// The top-level subcommand enum.
+// `#[derive(Subcommand)]` tells clap this is a set of mutually exclusive commands.
+// When the user runs `fsrt mint-fct ...`, clap fills in `Command::MintFct`.
+// When no subcommand is given, `command` is None and we fall through to the
+// existing scan behaviour — so nothing breaks for current users.
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Mint a Forge Context Token (FCT).
+    MintFct(mint_fct::MintFctArgs),
+
+    /// Mint a Forge Invocation Token (FIT).
+    /// Internally mints an FCT first, then uses it for the FIT.
+    MintFit(mint_fit::MintFitArgs),
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    // The optional subcommand — if present, we route to it instead of scanning.
+    #[command(subcommand)]
+    command: Option<Command>,
+
     #[arg(short, long)]
     debug: bool,
 
@@ -828,12 +850,39 @@ pub(crate) fn scan_directory<'a>(
     Ok(reporter.into_report())
 }
 
+// Print a subcommand error via Display (real newlines, no Debug wrapper) and
+// exit non-zero. On success, returns Ok(()) so main can propagate it normally.
+fn exit_on_err(result: Result<()>) -> Result<()> {
+    if let Err(err) = result {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let mut args = Args::parse();
     tracing_subscriber::registry()
         .with(HierarchicalLayer::new(2))
         .with(EnvFilter::from_env("FORGE_LOG"))
         .init();
+
+    // Check if a subcommand was given.
+    // If the user ran `fsrt mint-fct ...`, route to run_mint_fct() and exit.
+    // If no subcommand was given, fall through to the existing scan behaviour —
+    // so `fsrt /path/to/app` keeps working exactly as before.
+    // Route to a subcommand if one was given. On error, print the message via
+    // Display (honours real newlines) and exit non-zero — rather than returning
+    // the error to main, which would Debug-print it (escaping `\n` and wrapping
+    // it in the error variant name, e.g. CookieExpired("...\n...")).
+    if let Some(Command::MintFct(mint_fct_args)) = &args.command {
+        return exit_on_err(mint_fct::run_mint_fct(mint_fct_args));
+    }
+
+    if let Some(Command::MintFit(mint_fit_args)) = &args.command {
+        return exit_on_err(mint_fit::run_mint_fit(mint_fit_args));
+    }
+
     let dirs = std::mem::take(&mut args.dirs);
 
     let secretdata_file = include_str!("../../../secretdata.yaml");

--- a/crates/fsrt/src/mint_common.rs
+++ b/crates/fsrt/src/mint_common.rs
@@ -1,15 +1,11 @@
 //! Shared types and functions used by both `mint_fct` and `mint_fit`.
 //!
 //! This module contains:
-//!   - Config structs (deserialised from the YAML config files in `scripts/`)
+//!   - Config structs (deserialised from the `fsrt-remote.toml` config file)
 //!   - Auth header construction
 //!   - GraphQL HTTP POST via `ureq`
 //!   - Template rendering
 //!   - The core `mint_fct_jwt()` function, which both subcommands call
-
-// ============================================================================
-// Imports
-// ============================================================================
 
 use base64::{
     Engine as _,
@@ -23,10 +19,7 @@ use std::fs;
 use std::path::Path;
 
 use forge_loader::manifest::ForgeManifest;
-
-// ============================================================================
-// Constants
-// ============================================================================
+use tracing::{info, warn};
 
 // The default FCT mutation for Confluence apps.
 pub const DEFAULT_CONFLUENCE_MUTATION: &str = r#"mutation useGetContextTokenMutation($cloudId: ID!, $input: ConfluenceForgeContextTokenRequestInput!) {
@@ -70,13 +63,7 @@ pub const DEFAULT_GLOBAL_APP_MUTATION: &str = r#"mutation SignForgeContextToken(
 
 pub const GLOBAL_APP_OPERATION_NAME: &str = "SignForgeContextToken";
 
-// ============================================================================
-// Error type
-// ============================================================================
-
-// `MintError` is the shared error type for both mint_fct and mint_fit.
-// `thiserror::Error` auto-generates the Display and Error trait impls from
-// the `#[error("...")]` attributes — no boilerplate needed.
+// Error types
 #[derive(Debug, thiserror::Error)]
 pub enum MintError {
     #[error("{0}")]
@@ -102,9 +89,12 @@ pub enum MintError {
     #[error("FCT minting failed: {0}")]
     FctFailed(String),
 
+    // Returned when the FIT mint reaches the server but no invocation token is
+    // returned (GraphQL errors, or a missing token in the response).
+    #[error("{0}")]
+    FitFailed(String),
+
     // Returned when the configured session cookie's JWT `exp` is in the past.
-    // We fail fast here instead of sending a stale cookie and getting a
-    // confusing HTTP 401 downstream. The message tells the tester how to renew.
     #[error("{0}")]
     CookieExpired(String),
 }
@@ -112,20 +102,7 @@ pub enum MintError {
 // Convenience alias — write `Result<T>` instead of `Result<T, MintError>`.
 pub type Result<T> = std::result::Result<T, MintError>;
 
-// ============================================================================
-// Config structs
-// ============================================================================
-// These deserialise from the YAML config files in `scripts/`.
-// Both `mint_fct` and `mint_fit` use the same YAML format.
-
-// Which Atlassian product the FCT/FIT is being minted for.
-// Controls which GraphQL mutation is used:
-//   Confluence → confluence_generateForgeContextToken
-//   GlobalApp  → globalApp_signForgeContextTokens
-//
-// Set via `product:` in the YAML config file:
-//   product: confluence
-//   product: global
+// Config structs, deserialised from the `fsrt-remote.toml` config file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Product {
@@ -142,19 +119,12 @@ impl std::fmt::Display for Product {
     }
 }
 
-// `#[derive(Debug, Deserialize, Serialize)]`:
-//   Debug       → printable for logging (`println!("{:?}", ...)`)
-//   Deserialize → can be built from YAML text (`serde_yaml::from_str`)
-//   Serialize   → can be turned into JSON (`serde_json::to_value`)
-//                 needed because we embed the whole config as the template context
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MintFctConfig {
-    // Which Atlassian product to mint the token for.
-    // Required — must be "confluence" or "global" in the YAML config.
+    // Required: which Atlassian product to mint the token for.
     pub product: Product,
 
     // The Atlassian GraphQL gateway URL.
-    // e.g. "https://lhe2.atlassian.net/gateway/api/graphql"
     pub graphql_endpoint: String,
 
     // Optional: override the default FCT GraphQL mutation.
@@ -171,30 +141,24 @@ pub struct MintFctConfig {
     // Required when product: global.
     pub global: Option<GlobalAppConfig>,
 
-    // The GraphQL variables template — an arbitrary JSON/YAML object containing
+    // The GraphQL variables template — an arbitrary object containing
     // `${...}` placeholders that get substituted at runtime.
     pub variables: Option<JsonValue>,
 }
 
-// The `auth:` section of the config.
-// Supports two types matching the YAML config files in `scripts/`:
-//   "raw_cookie"      — full Cookie header pasted from Burp/DevTools
-//   "basic_api_token" — Atlassian API token (email + token file)
+// `auth` section of the config, either session cookie or API token
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AuthConfig {
-    // YAML key is `type` — a reserved word in Rust, so we rename it.
+    // Config key is `type`, renamed
     #[serde(rename = "type", default = "default_auth_type")]
     pub auth_type: String,
 
-    // --- raw_cookie ---
     // The full Cookie header value, either inline or from a file.
     pub raw_cookie: Option<String>,
     pub raw_cookie_file: Option<String>,
 
-    // --- basic_api_token ---
-    // Email is not a secret — it's inline in the config.
-    // API token is a secret — read from inline value or a file.
     pub email: Option<String>,
+    // API token is a secret — read from inline value or a file.
     pub api_token: Option<String>,
     pub api_token_file: Option<String>,
 }
@@ -204,8 +168,6 @@ fn default_auth_type() -> String {
 }
 
 // The `confluence:` section of the config.
-// `#[derive(Clone)]` — needed because we clone it when building the template context.
-// `Serialize` — needed so `serde_json::to_value(config)` includes this struct.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ConfluenceConfig {
     pub cloud_id: Option<String>,
@@ -218,18 +180,15 @@ pub struct ConfluenceConfig {
     pub environment_type: Option<String>,
     pub local_id: Option<String>,
     pub module_key: Option<String>,
+    // Declared remote a FIT should target, defaults to first remote in manifest.
+    pub remote_key: Option<String>,
     pub site_url: Option<String>,
     // Named Forge environment slot; used to look up environment_id when it
-    // isn't supplied explicitly. Defaults to "development".
+    // isn't supplied explicitly. Defaults to DEFAULT_ENVIRONMENT_KEY.
     pub environment_key: Option<String>,
 }
 
-// The `global:` section of the config — used when product: global.
-// Mirrors the fields needed to build a GlobalAppSignForgeContextTokensInput.
-//
-// `environment_id` is optional: if omitted, it is resolved automatically from
-// the Forge platform via `fetch_app_environment()` (see below), using the app
-// id (from the manifest) and `environment_key` (defaults to "development").
+// The `global:` section of the config.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GlobalAppConfig {
     pub cloud_id: Option<String>,
@@ -237,17 +196,14 @@ pub struct GlobalAppConfig {
     pub environment_id: Option<String>,
     pub environment_type: Option<String>,
     pub module_key: Option<String>,
-    // Named Forge environment slot ("development" | "staging" | "production").
-    // Used to look up environment_id when it isn't supplied explicitly.
+    // Declared remote a FIT should target, defaults to first remote in manifest.
+    pub remote_key: Option<String>,
+    // Named Forge environment slot; used to look up environment_id when it
+    // isn't supplied explicitly. Defaults to DEFAULT_ENVIRONMENT_KEY.
     pub environment_key: Option<String>,
 }
 
-// ============================================================================
 // Manifest context
-// ============================================================================
-// What we extract from the Forge app's manifest.yml.
-// Used to fill `${manifest.app_id_bare}`, `${manifest.module_key}`, etc.
-
 #[derive(Debug, Clone)]
 pub struct ManifestContext {
     // Full ARI: "ari:cloud:ecosystem::app/8bdd65d0-..."
@@ -258,159 +214,58 @@ pub struct ManifestContext {
     pub module_key: Option<String>,
     pub module_type: Option<String>,
     // Resolved from the Forge platform via fetch_app_environment().
-    // environment_id: the UUID of the named environment slot.
-    // app_version: the latest deployed version string (e.g. "43.0.0").
-    // Both are None until the lookup runs; the default variable templates
-    // reference them as ${manifest.environment_id} and ${manifest.app_version}.
     pub environment_id: Option<String>,
     pub app_version: Option<String>,
 }
 
-// ============================================================================
-// extract_manifest_context()
-// ============================================================================
 // Reads a parsed ForgeManifest and returns a ManifestContext.
 //
-// Module/remote detection lives in forge_loader (see ForgeModules methods), so
-// this works entirely off the typed manifest — the manifest is read from disk
-// once and parsed once by the caller.
-// Resolve the module that owns a `--function` value, tolerating both the bare
-// "<function>" form and the "<resolver>.<function>" form. Tries the whole
-// string first, then the segment after the last '.'.
-fn detect_module_for_function<'a>(
-    manifest: &ForgeManifest<'a>,
-    function: &str,
-) -> Option<(&'a str, &'static str)> {
-    manifest
-        .modules
-        .detect_fct_module_for_function(function)
-        .or_else(|| {
-            function
-                .rsplit_once('.')
-                .and_then(|(_, tail)| manifest.modules.detect_fct_module_for_function(tail))
-        })
-}
-
+// `module_key` is an optional override from config; when absent, the first
+// FCT-capable module in the manifest is auto-detected.
 pub fn extract_manifest_context(
     manifest: &ForgeManifest<'_>,
     module_key: Option<&str>,
 ) -> ManifestContext {
-    // No invoked function is known in the mint-only paths, so module selection
-    // uses first-module auto-detection (historical behaviour). With no
-    // function supplied, the function-aware error path cannot trigger, so the
-    // Result is always Ok here.
-    extract_manifest_context_for_function(manifest, module_key, None)
-        .expect("extract_manifest_context_for_function cannot fail without a function")
-}
-
-/// Like [`extract_manifest_context`], but aware of the backend resolver
-/// `function` being invoked.
-///
-/// Module selection precedence:
-///   1. An explicit `module_key` (from config) always wins. If it does not own
-///      the invoked `function`, a warning is emitted — the mismatch is usually a
-///      config mistake and would otherwise fail confusingly at the remote hop.
-///   2. Otherwise, if a `function` is supplied, select the module whose
-///      `resolver.function` matches it. This is the correct choice for apps
-///      where several modules share one resolver, or where the first-declared
-///      module is endpoint-backed (so blind first-module detection picks a
-///      `moduleKey` that does not match the invoked resolver). If no module
-///      declares that function, this is a hard error — we do NOT fall back to
-///      an unrelated module, because sending a mismatched `moduleKey` fails
-///      confusingly at the remote hop (e.g. a 404 text/html from the backend).
-///   3. Otherwise (no function supplied), fall back to first-module
-///      auto-detection.
-pub fn extract_manifest_context_for_function(
-    manifest: &ForgeManifest<'_>,
-    module_key: Option<&str>,
-    function: Option<&str>,
-) -> Result<ManifestContext> {
     let app_id = manifest.app.id.to_string();
 
     // Strip the ARI prefix to get the bare UUID.
-    // "ari:cloud:ecosystem::app/8bdd65d0-..." → "8bdd65d0-..."
     let app_id_bare = app_id.rsplit('/').next().unwrap_or(&app_id).to_string();
 
     let app_name = manifest.app.name.map(|s| s.to_string());
 
     let (detected_key, detected_type) = match module_key {
-        // 1. Explicit override from config — inferring its type from the
-        //    manifest. Warn if it doesn't own the invoked function.
-        Some(key) => {
-            if let Some(func) = function {
-                let owns_func = detect_module_for_function(manifest, func)
-                    .is_some_and(|(matched_key, _)| matched_key == key);
-                if !owns_func {
-                    eprintln!(
-                        "warning: configured module_key '{key}' does not declare \
-                         resolver function '{func}'; the invocation's moduleKey may \
-                         not match the invoked resolver."
-                    );
-                }
-            }
-            (
-                Some(key.to_string()),
-                manifest
-                    .modules
-                    .fct_module_type_for_key(key)
-                    .map(|t| t.to_string()),
-            )
-        }
-        // 2. Select the module that owns the invoked function. No fallback: a
-        //    mismatched moduleKey fails confusingly downstream, so error out.
-        None => match function {
-            Some(func) => match detect_module_for_function(manifest, func) {
-                Some((key, module_type)) => (Some(key.to_string()), Some(module_type.to_string())),
-                None => {
-                    return Err(MintError::Config(format!(
-                        "no module in the manifest declares resolver function '{func}'. \
-                         Check the --function value, or set module_key in the config to \
-                         the module that owns this resolver."
-                    )));
-                }
-            },
-            // 3. No function supplied — first-module auto-detection.
-            None => match manifest.modules.detect_fct_module() {
-                Some((key, module_type)) => (Some(key.to_string()), Some(module_type.to_string())),
-                None => (None, None),
-            },
+        // Explicit override from config.
+        Some(key) => (
+            Some(key.to_string()),
+            manifest
+                .modules
+                .fct_module_type_for_key(key)
+                .map(|t| t.to_string()),
+        ),
+        // No override — auto-detect the first FCT-capable module.
+        None => match manifest.modules.detect_fct_module() {
+            Some((key, module_type)) => (Some(key.to_string()), Some(module_type.to_string())),
+            None => (None, None),
         },
     };
 
-    Ok(ManifestContext {
+    ManifestContext {
         app_id,
         app_id_bare,
         app_name,
         module_key: detected_key,
         module_type: detected_type,
-        // Filled in later by resolve_environment() if a lookup runs.
         environment_id: None,
         app_version: None,
-    })
+    }
 }
 
-// ============================================================================
-// detect_remote_key()
-// ============================================================================
 // Walks the raw YAML manifest to find the `key` of the first declared remote.
-//
-// A remote in manifest.yml looks like:
-//   remotes:
-//     - key: my-remote-backend
-//       baseUrl: https://my-backend.com
-//       auth:
-//         appUser: {}
-//
-// Returns None if no remotes are declared — the caller (run_mint_fit) will
-// return a clear error in that case.
-//
-// An optional `override_key` (from the config) takes priority over
-// auto-detection — needed for apps with multiple remotes.
 pub fn detect_remote_key(
     manifest: &ForgeManifest<'_>,
     override_key: Option<&str>,
 ) -> Option<String> {
-    // Config override takes priority over auto-detection.
+    // Config override takes priority.
     if let Some(key) = override_key
         && !key.is_empty()
     {
@@ -418,8 +273,7 @@ pub fn detect_remote_key(
     }
 
     // Otherwise take the key of the first declared remote from the typed
-    // manifest. Returns None if no remotes are declared or the first one has
-    // no key.
+    // manifest.
     manifest
         .remotes
         .as_ref()?
@@ -428,24 +282,19 @@ pub fn detect_remote_key(
         .filter(|key| !key.is_empty())
 }
 
-// ============================================================================
-// load_secret_from_config()
-// ============================================================================
-// Reads a secret from one of two sources (in priority order):
-//   1. Inline value in the config (e.g. `raw_cookie: "eyJ..."`)
-//   2. A file path              (e.g. `raw_cookie_file: "./session-cookie.txt"`)
+// Reads a secret from inline value or file path (will be changed later)
 pub fn load_secret_from_config(
     inline: Option<&str>,
     file_path: Option<&str>,
 ) -> Result<Option<String>> {
-    // 1. Inline value takes highest priority.
+    // Inline value takes highest priority.
     if let Some(v) = inline
         && !v.is_empty()
     {
         return Ok(Some(v.to_string()));
     }
 
-    // 2. Read from a file.
+    // Read from a file.
     if let Some(path) = file_path
         && !path.is_empty()
     {
@@ -458,22 +307,14 @@ pub fn load_secret_from_config(
     Ok(None)
 }
 
-// ============================================================================
-// build_auth_headers()
-// ============================================================================
 // Reads the `auth:` section of the config and returns the HTTP headers needed
 // to authenticate the request. Returns a HashMap<header_name, header_value>.
 pub fn build_auth_headers(auth: &AuthConfig) -> Result<HashMap<String, String>> {
     let mut headers = HashMap::new();
 
-    println!("\n=== Auth material ===");
-    println!("WARNING: Do not paste this output into public tickets, logs, or chat.");
+    info!("building auth headers from config — this uses sensitive credentials");
 
     match auth.auth_type.as_str() {
-        // ------------------------------------------------------------------
-        // raw_cookie: the full Cookie header pasted from Burp/DevTools.
-        // e.g. "tenant.session.token=eyJ...; atlassian.xsrf.token=5748..."
-        // ------------------------------------------------------------------
         "raw_cookie" => {
             let raw = load_secret_from_config(
                 auth.raw_cookie.as_deref(),
@@ -486,15 +327,9 @@ pub fn build_auth_headers(auth: &AuthConfig) -> Result<HashMap<String, String>> 
                 )
             })?;
 
-            // Only print the first 80 chars — never log a full session token.
-            println!("Cookie (first 80 chars): {}...", &raw[..raw.len().min(80)]);
+            info!(bytes = raw.len(), "loaded session cookie");
 
-            // Check the session token's `exp` claim locally (no network call).
-            // If we can definitively tell it is expired, hard-fail here with
-            // actionable advice — sending a stale cookie only yields a confusing
-            // HTTP 401 later. If we cannot read an `exp` (non-standard cookie
-            // format), we do NOT block: check_cookie_expiry() prints a warning
-            // and we proceed, letting the server be the final authority.
+            // Check the session token's `exp` claim locally for expiry
             if let Some(secs_ago) = cookie_expired_secs_ago(&raw) {
                 return Err(MintError::CookieExpired(format!(
                     "Session cookie EXPIRED {} ago. Renew it (e.g. re-copy the \
@@ -508,10 +343,7 @@ pub fn build_auth_headers(auth: &AuthConfig) -> Result<HashMap<String, String>> 
             headers.insert("Cookie".to_string(), raw.trim().to_string());
         }
 
-        // ------------------------------------------------------------------
         // basic_api_token: Atlassian API token encoded as HTTP Basic auth.
-        // The gateway accepts base64("email:api_token") in the Authorization header.
-        // ------------------------------------------------------------------
         "basic_api_token" => {
             let email = auth
                 .email
@@ -532,15 +364,10 @@ pub fn build_auth_headers(auth: &AuthConfig) -> Result<HashMap<String, String>> 
                 )
                     })?;
 
-            // HTTP Basic auth: base64-encode "email:token"
             let credentials = format!("{}:{}", email.trim(), token.trim());
             let encoded = B64.encode(credentials.as_bytes());
 
-            println!("Basic auth email: {}", email.trim());
-            println!(
-                "Authorization: Basic {}... (truncated)",
-                &encoded[..encoded.len().min(20)]
-            );
+            info!(email = %email.trim(), "using basic API token auth");
             headers.insert("Authorization".to_string(), format!("Basic {}", encoded));
         }
 
@@ -555,21 +382,9 @@ pub fn build_auth_headers(auth: &AuthConfig) -> Result<HashMap<String, String>> 
     Ok(headers)
 }
 
-// ============================================================================
 // Session-cookie expiry checking
-// ============================================================================
-// The raw cookie contains `tenant.session.token`, which is a JWT. Its `exp`
-// claim tells us exactly when the session dies — we can read it locally without
-// any network round-trip. These helpers extract that claim and print a status
-// message so an expired cookie is caught up front (rather than surfacing as an
-// opaque HTTP 401 mid-request).
-
 const SESSION_COOKIE_NAME: &str = "tenant.session.token";
 
-// Pull the `tenant.session.token` value out of a full Cookie header string.
-// The header looks like "name1=val1; tenant.session.token=eyJ...; name2=val2".
-// Falls back to treating the whole trimmed string as the token if no explicit
-// `name=` prefix is present (i.e. the file contains only the bare JWT).
 fn extract_session_token(raw_cookie: &str) -> Option<&str> {
     for pair in raw_cookie.split(';') {
         let pair = pair.trim();
@@ -577,8 +392,6 @@ fn extract_session_token(raw_cookie: &str) -> Option<&str> {
             return Some(value);
         }
     }
-    // No "name=" pair matched. If the whole thing looks like a bare JWT
-    // (three dot-separated segments and no '='), use it directly.
     let trimmed = raw_cookie.trim();
     if !trimmed.contains('=') && trimmed.split('.').count() == 3 {
         return Some(trimmed);
@@ -586,17 +399,14 @@ fn extract_session_token(raw_cookie: &str) -> Option<&str> {
     None
 }
 
-// Decode a JWT's `exp` (expiry) claim, in Unix seconds. Returns None if the
-// token isn't a well-formed JWT or has no numeric `exp`.
+// Decode a JWT's `exp` (expiry) claim
 fn decode_jwt_exp(token: &str) -> Option<i64> {
-    // JWT = header.payload.signature — the middle segment is the JSON payload.
     let payload_b64 = token.split('.').nth(1)?;
     let payload_bytes = B64_URL.decode(payload_b64).ok()?;
     let payload: JsonValue = serde_json::from_slice(&payload_bytes).ok()?;
     payload.get("exp")?.as_i64()
 }
 
-// Format a duration in seconds as a short human string, e.g. "2h 5m", "3d 4h".
 fn format_duration(seconds: i64) -> String {
     let seconds = seconds.abs();
     let days = seconds / 86_400;
@@ -614,10 +424,6 @@ fn format_duration(seconds: i64) -> String {
 }
 
 // Definitive expiry check used to hard-fail before sending a stale cookie.
-// Returns Some(seconds_since_expiry) ONLY when the session token is present,
-// is a readable JWT, and its `exp` is in the past. Returns None when the
-// cookie is still valid OR when we cannot read an `exp` (non-standard format) —
-// i.e. "don't block unless we are sure it is expired".
 fn cookie_expired_secs_ago(raw_cookie: &str) -> Option<i64> {
     let token = extract_session_token(raw_cookie)?;
     let exp = decode_jwt_exp(token)?;
@@ -628,23 +434,20 @@ fn cookie_expired_secs_ago(raw_cookie: &str) -> Option<i64> {
     (exp <= now).then_some(now - exp)
 }
 
-// Inspect the raw cookie's session token and print its expiry status. Returns
-// true if the token is present and not yet expired, false otherwise. Purely
-// informational — it does not block the request (the hard block lives in
-// build_auth_headers via cookie_expired_secs_ago).
+// Inspect the raw cookie's session token and print its expiry status.
 pub fn check_cookie_expiry(raw_cookie: &str) -> bool {
     let Some(token) = extract_session_token(raw_cookie) else {
-        println!(
-            "WARNING: could not find '{SESSION_COOKIE_NAME}' in the cookie — \
-             cannot check expiry."
+        warn!(
+            cookie_name = SESSION_COOKIE_NAME,
+            "could not find session cookie — cannot check expiry"
         );
         return false;
     };
 
     let Some(exp) = decode_jwt_exp(token) else {
-        println!(
-            "WARNING: could not read an `exp` claim from '{SESSION_COOKIE_NAME}' \
-             (not a JWT?) — cannot check expiry."
+        warn!(
+            cookie_name = SESSION_COOKIE_NAME,
+            "could not read an `exp` claim (not a JWT?) — cannot check expiry"
         );
         return false;
     };
@@ -655,29 +458,24 @@ pub fn check_cookie_expiry(raw_cookie: &str) -> bool {
         .unwrap_or(0);
 
     if exp <= now {
-        println!(
-            "WARNING: session cookie EXPIRED {} ago (exp={}). \
-             Renew it (e.g. re-run the session-cookie harvester) before minting.",
-            format_duration(now - exp),
+        warn!(
+            expired_ago = %format_duration(now - exp),
             exp,
+            "session cookie EXPIRED — renew it before minting"
         );
         false
     } else {
-        println!(
-            "Session cookie valid — expires in {} (exp={}).",
-            format_duration(exp - now),
+        info!(
+            expires_in = %format_duration(exp - now),
             exp,
+            "session cookie valid"
         );
         true
     }
 }
 
-// ============================================================================
-// render_template() and helpers
-// ============================================================================
 // Walks a JSON value tree and replaces every "${dotted.path}" placeholder
 // with the value found at that path in the template context.
-
 pub fn render_template(value: &JsonValue, context: &JsonValue) -> JsonValue {
     match value {
         JsonValue::Object(map) => {
@@ -721,7 +519,6 @@ fn render_string(s: &str, context: &JsonValue) -> JsonValue {
 }
 
 // Walks a JsonValue by a dotted path string.
-// "config.confluence.cloud_id" → context["config"]["confluence"]["cloud_id"]
 pub fn get_path<'a>(context: &'a JsonValue, path: &str) -> Option<&'a JsonValue> {
     let mut cur = context;
     for part in path.split('.') {
@@ -730,12 +527,8 @@ pub fn get_path<'a>(context: &'a JsonValue, path: &str) -> Option<&'a JsonValue>
     Some(cur)
 }
 
-// ============================================================================
-// post_graphql()
-// ============================================================================
 // Sends a GraphQL POST request to the Atlassian gateway and returns
-// (http_status_code, response_body_text).
-// This is the ONLY place in the codebase that uses `ureq`.
+// (http_status_code, response_body_text) using ureq.
 pub fn post_graphql(
     endpoint: &str,
     operation_name: &str,
@@ -744,10 +537,8 @@ pub fn post_graphql(
     variables: &JsonValue,
 ) -> Result<(u16, String)> {
     // Extract origin from the endpoint URL for CSRF headers.
-    // "https://lhe2.atlassian.net/gateway/api/graphql" → "https://lhe2.atlassian.net"
     let origin = endpoint.split('/').take(3).collect::<Vec<_>>().join("/");
 
-    // Append operation name as a query param — gateway uses this for routing.
     let url = format!("{}?q={}", endpoint, operation_name);
 
     let body = serde_json::json!({
@@ -757,8 +548,6 @@ pub fn post_graphql(
     });
 
     // Build the ureq POST request.
-    // `.set(name, value)` adds an HTTP header.
-    // `ureq::post(&url)` returns a request builder.
     let mut request = ureq::post(&url)
         .set("Content-Type", "application/json")
         .set("Accept", "application/json")
@@ -772,12 +561,10 @@ pub fn post_graphql(
              AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
         );
 
-    // Add auth headers (Cookie or Authorization).
     for (name, value) in auth_headers {
         request = request.set(name, value);
     }
 
-    // `.send_json()` serialises the body and sends the request.
     match request.send_json(&body) {
         Ok(response) => {
             let status = response.status();
@@ -787,7 +574,6 @@ pub fn post_graphql(
             Ok((status, text))
         }
         Err(ureq::Error::Status(code, response)) => {
-            // HTTP 4xx/5xx — still read the body for error details.
             let text = response
                 .into_string()
                 .unwrap_or_else(|_| "<unreadable response body>".to_string());
@@ -797,29 +583,8 @@ pub fn post_graphql(
     }
 }
 
-// ============================================================================
-// load_config()
-// ============================================================================
 // Loads and deserialises the `fsrt-remote.toml` config file into a
 // `MintFctConfig` using the `config` crate (config-rs).
-//
-// The `config` crate is a layered configuration system: sources are added in
-// priority order and merged, then the merged result is deserialised into a
-// typed struct via serde. Right now we use a single source — the TOML file —
-// but the builder pattern makes it trivial to add more layers later (e.g. an
-// `Environment` source so secrets like the session cookie can be supplied via
-// env vars instead of on disk):
-//
-//     Config::builder()
-//         .add_source(File::from(path))                       // fsrt-remote.toml
-//         .add_source(Environment::with_prefix("FSRT")        // FSRT_AUTH__RAW_COOKIE=...
-//             .separator("__"))
-//         .build()?
-//
-// `File::from(&Path)` auto-detects the format from the file extension, so a
-// `.toml` file is parsed as TOML. `try_deserialize()` then pours the merged
-// values into `MintFctConfig` — the exact same struct serde_yaml used to fill,
-// so all the `#[serde(...)]` attributes and downstream code are unchanged.
 pub fn load_config(config_path: &std::path::Path) -> Result<MintFctConfig> {
     if !config_path.exists() {
         return Err(MintError::Config(format!(
@@ -836,28 +601,9 @@ pub fn load_config(config_path: &std::path::Path) -> Result<MintFctConfig> {
     Ok(cfg)
 }
 
-// ============================================================================
-// fetch_app_environment() / resolve_environment()
-// ============================================================================
-// Resolves the app's environment_id (and latest deployed version) from the
-// Forge platform, so the pen tester doesn't have to paste a UUID or a version
-// string into the config.
-//
-// The query is app-scoped: given the app id (already read from manifest.yml)
-// and a named environment slot ("development" / "staging" / "production"), the
-// platform returns the environment UUID and the latest deployed version.
-//
-//   app(id: $appId) {
-//     environmentByKey(key: $envKey) { id }
-//     ...latest version...
-//   }
-
-// Default named environment slot when the config doesn't specify one.
-// The Forge platform's default development environment has the key "default"
-// (its `type` is DEVELOPMENT). Override via `environment_key` in the config.
+// Resolve app's environmentId and versionId
 pub const DEFAULT_ENVIRONMENT_KEY: &str = "default";
 
-// The read query that resolves environment_id + latest app version.
 pub const APP_ENVIRONMENT_QUERY: &str = r#"query GetAppEnvironment($appId: ID!, $envKey: String!) {
   app(id: $appId) {
     id
@@ -878,12 +624,10 @@ pub const APP_ENVIRONMENT_OPERATION_NAME: &str = "GetAppEnvironment";
 #[derive(Debug, Clone)]
 pub struct AppEnvironment {
     pub environment_id: String,
-    // Latest deployed version, if the app has any deployed versions.
     pub app_version: Option<String>,
 }
 
 // Performs the GraphQL query and parses out the environment id + version.
-// Reuses the shared post_graphql() helper — same endpoint, same auth headers.
 pub fn fetch_app_environment(
     endpoint: &str,
     auth_headers: &HashMap<String, String>,
@@ -923,8 +667,6 @@ pub fn fetch_app_environment(
         })?
         .to_string();
 
-    // Version is best-effort — an app may have no deployed versions yet.
-    // Pick the node flagged isLatest, falling back to the first node.
     let app_version = env
         .and_then(|e| e.get("versions"))
         .and_then(|v| v.get("nodes"))
@@ -950,19 +692,11 @@ pub fn fetch_app_environment(
 }
 
 // High-level, opt-in resolver used by both subcommands.
-//
-// If the config already supplies `environment_id`, we trust it and skip the
-// network round-trip (the config value acts as an override/cache). Otherwise we
-// call fetch_app_environment() using the config's `environment_key` (defaulting
-// to "development") and populate manifest_ctx.environment_id + app_version so
-// build_variables() can reference them.
 pub fn resolve_environment(
     config: &MintFctConfig,
     manifest_ctx: &mut ManifestContext,
     auth_headers: &HashMap<String, String>,
 ) -> Result<()> {
-    // Read the config's explicit environment_id / environment_key for the
-    // active product, if any.
     let (explicit_id, env_key) = match config.product {
         Product::Confluence => {
             let c = config.confluence.as_ref();
@@ -980,7 +714,6 @@ pub fn resolve_environment(
         }
     };
 
-    // Explicit environment_id in the config short-circuits the lookup.
     if let Some(id) = explicit_id {
         manifest_ctx.environment_id = Some(id);
         return Ok(());
@@ -988,10 +721,6 @@ pub fn resolve_environment(
 
     let env_key = env_key.unwrap_or_else(|| DEFAULT_ENVIRONMENT_KEY.to_string());
 
-    println!(
-        "\n=== Resolving environment '{}' via Forge platform ===",
-        env_key
-    );
     let app_env = fetch_app_environment(
         &config.graphql_endpoint,
         auth_headers,
@@ -999,26 +728,14 @@ pub fn resolve_environment(
         &env_key,
     )?;
 
-    println!("  environment_id: {}", app_env.environment_id);
-    println!("  app_version:    {:?}", app_env.app_version);
-
     manifest_ctx.environment_id = Some(app_env.environment_id);
     manifest_ctx.app_version = app_env.app_version;
 
     Ok(())
 }
 
-// ============================================================================
-// load_manifest()
-// ============================================================================
 // Shared manifest loading logic — reads the manifest.yml (or .yaml) from an app
 // directory exactly once and returns its raw text.
-//
-// The returned String must be kept alive by the caller because the typed
-// `ForgeManifest` borrows from it. Callers parse it once via
-// `serde_yaml::from_str` — module/remote details are then read through the
-// typed accessors on `ForgeManifest`/`ForgeModules`, so the manifest is never
-// parsed a second time.
 pub fn load_manifest(app_dir: &Path) -> Result<String> {
     let mut manifest_path = app_dir.join("manifest.yaml");
     if !manifest_path.exists() {
@@ -1034,22 +751,12 @@ pub fn load_manifest(app_dir: &Path) -> Result<String> {
     Ok(fs::read_to_string(&manifest_path)?)
 }
 
-// ============================================================================
-// build_variables()
-// ============================================================================
 // Builds the final FCT GraphQL variables by rendering the template from the
 // config against the manifest + config context.
-// Branches on config.product to build the correct variable shape for each API.
 pub fn build_variables(
     config: &MintFctConfig,
     manifest_ctx: &ManifestContext,
 ) -> Result<JsonValue> {
-    // Build the template context:
-    //   { "manifest": {...}, "config": <whole MintFctConfig as JSON> }
-    //
-    // This means ${config.confluence.cloud_id} and ${config.global.cloud_id}
-    // resolve correctly because MintFctConfig has both "confluence" and "global"
-    // fields that serde serialises by name.
     let config_value =
         serde_json::to_value(config).unwrap_or(JsonValue::Object(Default::default()));
 
@@ -1060,23 +767,16 @@ pub fn build_variables(
             "app_name":       manifest_ctx.app_name,
             "module_key":     manifest_ctx.module_key,
             "module_type":    manifest_ctx.module_type,
-            // Resolved via resolve_environment() — used by the default templates
-            // so the pen tester never has to supply these.
             "environment_id": manifest_ctx.environment_id,
             "app_version":    manifest_ctx.app_version,
         },
         "config": config_value,
     });
 
-    // Use the variables template from the config if supplied — works for both
-    // products. Otherwise fall back to a product-specific minimal default.
     let template: JsonValue = if let Some(vars) = &config.variables {
         vars.clone()
     } else {
         match config.product {
-            // NOTE: environment_id and app_version come from the resolved
-            // manifest context (${manifest.environment_id} / ${manifest.app_version}),
-            // not from the config — so the pen tester never supplies them.
             Product::Confluence => serde_json::json!({
                 "cloudId": "${config.confluence.cloud_id}",
                 "input": {
@@ -1087,11 +787,6 @@ pub fn build_variables(
                         "extensionType": "xen:macro",
                         "installationId": "${config.confluence.installation_id}",
                         "context": {
-                            // moduleKey is what the platform bakes into the signed
-                            // FCT and later surfaces as the resolver's
-                            // `context.moduleKey`. Resolvers that branch on it
-                            // (e.g. moduleKey.includes('node')) throw
-                            // "Cannot read properties of undefined" without it.
                             "moduleKey": "${manifest.module_key}",
                             "type": "${manifest.module_type}",
                             "environmentId": "${manifest.environment_id}",
@@ -1110,9 +805,6 @@ pub fn build_variables(
                         "extensionType": "xen:${manifest.module_type}",
                         "installationId": "${config.global.installation_id}",
                         "context": {
-                            // See the Confluence note above: moduleKey must be in
-                            // the signed FCT so the resolver's context.moduleKey
-                            // is populated.
                             "moduleKey": "${manifest.module_key}",
                             "cloudId": "${config.global.cloud_id}",
                             "environmentId": "${manifest.environment_id}",
@@ -1136,37 +828,23 @@ pub fn build_variables(
     Ok(rendered)
 }
 
-// ============================================================================
-// mint_fct_jwt()
-// ============================================================================
-// The core FCT minting function — called by both `mint_fct::run_mint_fct()`
-// and `mint_fit::run_mint_fit()`.
-//
 // Takes a fully-prepared config, manifest context, and auth headers, and
 // returns the FCT JWT string on success.
-//
-// This separation is why mint_common.rs exists — both subcommands need to
-// mint an FCT, but only mint_fct prints the result as the final output.
-// mint_fit uses the JWT as an input to the FIT minting step.
 pub fn mint_fct_jwt(
     config: &MintFctConfig,
     manifest_ctx: &ManifestContext,
     auth_headers: &HashMap<String, String>,
 ) -> Result<String> {
-    // Verbose by default — mint-fct / mint-fit want the full GraphQL trace.
     mint_fct_jwt_opts(config, manifest_ctx, auth_headers, false)
 }
 
-// Same as `mint_fct_jwt`, but `quiet` suppresses the FCT GraphQL
-// variables/response diagnostics. `invoke-extension` uses quiet=true so its
-// output stays focused on the invocation, not the intermediate token mint.
+// Same as `mint_fct_jwt`, but `quiet` suppresses variables/response diagnostics
 pub fn mint_fct_jwt_opts(
     config: &MintFctConfig,
     manifest_ctx: &ManifestContext,
     auth_headers: &HashMap<String, String>,
     quiet: bool,
 ) -> Result<String> {
-    // Select mutation and operation name based on product.
     let (default_mutation, operation_name, response_key) = match config.product {
         Product::Confluence => (
             DEFAULT_CONFLUENCE_MUTATION,
@@ -1185,11 +863,10 @@ pub fn mint_fct_jwt_opts(
     let variables = build_variables(config, manifest_ctx)?;
 
     if !quiet {
-        println!("\n=== FCT GraphQL variables ===");
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&variables)
-                .unwrap_or_else(|_| "<serialisation error>".to_string())
+        info!(
+            variables = %serde_json::to_string_pretty(&variables)
+                .unwrap_or_else(|_| "<serialisation error>".to_string()),
+            "FCT GraphQL variables"
         );
     }
 
@@ -1201,20 +878,18 @@ pub fn mint_fct_jwt_opts(
         &variables,
     )?;
 
-    // Parse and (unless quiet) pretty-print the response.
     let parsed: JsonValue = serde_json::from_str(&body).map_err(|e| {
-        println!("{}", body); // print raw body if not valid JSON
+        warn!(response_body = %body, "FCT response was not valid JSON");
         MintError::Json(e)
     })?;
     if !quiet {
-        println!("\n=== FCT GraphQL response ===");
-        println!("HTTP status: {}", status);
-        println!("{}", serde_json::to_string_pretty(&parsed)?);
+        info!(
+            http_status = status,
+            response = %serde_json::to_string_pretty(&parsed).unwrap_or_default(),
+            "FCT GraphQL response"
+        );
     }
 
-    // Navigate to the FCT JWT in the response tree using the product-specific key.
-    // Confluence: data.confluence_generateForgeContextToken.forgeContextToken.jwt
-    // Global:     data.globalApp_signForgeContextTokens.tokens[0].jwt
     let fct_obj = parsed.get("data").and_then(|d| d.get(response_key));
 
     let success = fct_obj
@@ -1223,7 +898,6 @@ pub fn mint_fct_jwt_opts(
         .unwrap_or(false);
 
     if !success {
-        // Collect server-side error messages for a useful error.
         let errors: Vec<&str> = fct_obj
             .and_then(|o| o.get("errors"))
             .and_then(|e| e.as_array())
@@ -1241,9 +915,7 @@ pub fn mint_fct_jwt_opts(
         }));
     }
 
-    // Extract the JWT string — path differs by product:
-    //   Confluence: .forgeContextToken.jwt  (single object)
-    //   Global:     .tokens[0].jwt           (list, take first)
+    // Extract the JWT string — path differs by product
     let jwt = match config.product {
         Product::Confluence => fct_obj
             .and_then(|o| o.get("forgeContextToken"))
@@ -1266,13 +938,7 @@ pub fn mint_fct_jwt_opts(
     Ok(jwt.to_string())
 }
 
-// ============================================================================
 // Tests
-// ============================================================================
-// These cover the pure, network-free helpers shared by `mint_fct` and
-// `mint_fit`: dotted-path lookup, `${...}` template rendering, `Product`
-// display, and human-readable duration formatting. The GraphQL/HTTP paths are
-// intentionally not exercised here — they require a live Atlassian gateway.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1298,8 +964,6 @@ mod tests {
 
     #[test]
     fn render_whole_string_placeholder_preserves_type() {
-        // A string that is *only* a placeholder resolves to the underlying
-        // JSON value, keeping its original type (here: a number).
         let ctx = json!({ "count": 7 });
         let template = json!("${count}");
         assert_eq!(render_template(&template, &ctx), json!(7));
@@ -1307,7 +971,6 @@ mod tests {
 
     #[test]
     fn render_embedded_placeholder_produces_string() {
-        // A placeholder embedded in surrounding text is substituted as text.
         let ctx = json!({ "name": "world" });
         let template = json!("hello ${name}!");
         assert_eq!(render_template(&template, &ctx), json!("hello world!"));
@@ -1316,9 +979,7 @@ mod tests {
     #[test]
     fn render_missing_placeholder_becomes_empty_or_null() {
         let ctx = json!({});
-        // Whole-string placeholder → Null.
         assert_eq!(render_template(&json!("${gone}"), &ctx), json!(null));
-        // Embedded missing placeholder → empty replacement.
         assert_eq!(render_template(&json!("a${gone}b"), &ctx), json!("ab"));
     }
 
@@ -1337,7 +998,7 @@ mod tests {
     }
 
     #[test]
-    fn product_display_matches_yaml_values() {
+    fn product_display_matches_config_values() {
         assert_eq!(Product::Confluence.to_string(), "confluence");
         assert_eq!(Product::Global.to_string(), "global");
     }
@@ -1348,7 +1009,61 @@ mod tests {
         assert_eq!(format_duration(3 * 60), "3m");
         assert_eq!(format_duration(2 * 3600 + 5 * 60), "2h 5m");
         assert_eq!(format_duration(3 * 86_400 + 4 * 3600), "3d 4h");
-        // Negative inputs are treated as their absolute value.
         assert_eq!(format_duration(-45), "45s");
+    }
+
+    fn manifest_with_remotes(keys: &[&str]) -> String {
+        let remotes: Vec<String> = keys
+            .iter()
+            .map(|k| format!(r#"{{ "key": "{k}" }}"#))
+            .collect();
+        format!(
+            r#"{{
+                "app": {{ "name": "T", "id": "test-app" }},
+                "modules": {{}},
+                "remotes": [{}]
+            }}"#,
+            remotes.join(", ")
+        )
+    }
+
+    #[test]
+    fn detect_remote_key_override_wins() {
+        let json = manifest_with_remotes(&["first-remote", "second-remote"]);
+        let manifest: ForgeManifest<'_> = serde_json::from_str(&json).unwrap();
+        // An explicit override is used verbatim, even when remotes exist.
+        assert_eq!(
+            detect_remote_key(&manifest, Some("chosen-remote")),
+            Some("chosen-remote".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_remote_key_empty_override_falls_back() {
+        let json = manifest_with_remotes(&["first-remote", "second-remote"]);
+        let manifest: ForgeManifest<'_> = serde_json::from_str(&json).unwrap();
+        // An empty override is ignored; the first declared remote is used.
+        assert_eq!(
+            detect_remote_key(&manifest, Some("")),
+            Some("first-remote".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_remote_key_falls_back_to_first_remote() {
+        let json = manifest_with_remotes(&["first-remote", "second-remote"]);
+        let manifest: ForgeManifest<'_> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            detect_remote_key(&manifest, None),
+            Some("first-remote".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_remote_key_none_when_no_remotes() {
+        let json = manifest_with_remotes(&[]);
+        let manifest: ForgeManifest<'_> = serde_json::from_str(&json).unwrap();
+        // No remotes and no override → None (caller turns this into a clear error).
+        assert_eq!(detect_remote_key(&manifest, None), None);
     }
 }

--- a/crates/fsrt/src/mint_common.rs
+++ b/crates/fsrt/src/mint_common.rs
@@ -1,0 +1,1354 @@
+//! Shared types and functions used by both `mint_fct` and `mint_fit`.
+//!
+//! This module contains:
+//!   - Config structs (deserialised from the YAML config files in `scripts/`)
+//!   - Auth header construction
+//!   - GraphQL HTTP POST via `ureq`
+//!   - Template rendering
+//!   - The core `mint_fct_jwt()` function, which both subcommands call
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+use base64::{
+    Engine as _,
+    engine::general_purpose::{STANDARD as B64, URL_SAFE_NO_PAD as B64_URL},
+};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use forge_loader::manifest::ForgeManifest;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// The default FCT mutation for Confluence apps.
+pub const DEFAULT_CONFLUENCE_MUTATION: &str = r#"mutation useGetContextTokenMutation($cloudId: ID!, $input: ConfluenceForgeContextTokenRequestInput!) {
+  confluence_generateForgeContextToken(cloudId: $cloudId, input: $input) {
+    success
+    errors {
+      message
+      __typename
+    }
+    forgeContextToken {
+      jwt
+      expiresAt
+      extensionId
+      __typename
+    }
+    __typename
+  }
+}"#;
+
+pub const CONFLUENCE_OPERATION_NAME: &str = "useGetContextTokenMutation";
+
+// The default FCT mutation for global apps (Jira, Compass, Rovo, etc.).
+// Calls globalApp_signForgeContextTokens on XIS (Xen Invocation Service).
+// NOTE: Response returns a list of tokens (one per extensionContext entry).
+pub const DEFAULT_GLOBAL_APP_MUTATION: &str = r#"mutation SignForgeContextToken($input: GlobalAppSignForgeContextTokensInput!) {
+  globalApp_signForgeContextTokens(input: $input) {
+    success
+    errors {
+      message
+      __typename
+    }
+    tokens {
+      jwt
+      expiresAt
+      extensionId
+      __typename
+    }
+    __typename
+  }
+}"#;
+
+pub const GLOBAL_APP_OPERATION_NAME: &str = "SignForgeContextToken";
+
+// ============================================================================
+// Error type
+// ============================================================================
+
+// `MintError` is the shared error type for both mint_fct and mint_fit.
+// `thiserror::Error` auto-generates the Display and Error trait impls from
+// the `#[error("...")]` attributes — no boilerplate needed.
+#[derive(Debug, thiserror::Error)]
+pub enum MintError {
+    #[error("{0}")]
+    Config(String),
+
+    #[error("HTTP error: {0}")]
+    Http(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("YAML parse error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    #[error("config error: {0}")]
+    ConfigCrate(#[from] config::ConfigError),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    // Returned when the FCT mint succeeds at the HTTP level but the server
+    // reports a logical failure (e.g. bad cloud_id, bad installation_id).
+    #[error("FCT minting failed: {0}")]
+    FctFailed(String),
+
+    // Returned when the configured session cookie's JWT `exp` is in the past.
+    // We fail fast here instead of sending a stale cookie and getting a
+    // confusing HTTP 401 downstream. The message tells the tester how to renew.
+    #[error("{0}")]
+    CookieExpired(String),
+}
+
+// Convenience alias — write `Result<T>` instead of `Result<T, MintError>`.
+pub type Result<T> = std::result::Result<T, MintError>;
+
+// ============================================================================
+// Config structs
+// ============================================================================
+// These deserialise from the YAML config files in `scripts/`.
+// Both `mint_fct` and `mint_fit` use the same YAML format.
+
+// Which Atlassian product the FCT/FIT is being minted for.
+// Controls which GraphQL mutation is used:
+//   Confluence → confluence_generateForgeContextToken
+//   GlobalApp  → globalApp_signForgeContextTokens
+//
+// Set via `product:` in the YAML config file:
+//   product: confluence
+//   product: global
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Product {
+    Confluence,
+    Global,
+}
+
+impl std::fmt::Display for Product {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Product::Confluence => write!(f, "confluence"),
+            Product::Global => write!(f, "global"),
+        }
+    }
+}
+
+// `#[derive(Debug, Deserialize, Serialize)]`:
+//   Debug       → printable for logging (`println!("{:?}", ...)`)
+//   Deserialize → can be built from YAML text (`serde_yaml::from_str`)
+//   Serialize   → can be turned into JSON (`serde_json::to_value`)
+//                 needed because we embed the whole config as the template context
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MintFctConfig {
+    // Which Atlassian product to mint the token for.
+    // Required — must be "confluence" or "global" in the YAML config.
+    pub product: Product,
+
+    // The Atlassian GraphQL gateway URL.
+    // e.g. "https://lhe2.atlassian.net/gateway/api/graphql"
+    pub graphql_endpoint: String,
+
+    // Optional: override the default FCT GraphQL mutation.
+    pub mutation: Option<String>,
+
+    // Auth credentials — how to authenticate the HTTP request.
+    pub auth: AuthConfig,
+
+    // Confluence-specific IDs (cloud_id, installation_id, environment_id, etc.)
+    // Required when product: confluence.
+    pub confluence: Option<ConfluenceConfig>,
+
+    // Global app IDs (installation_id, environment_id, etc.)
+    // Required when product: global.
+    pub global: Option<GlobalAppConfig>,
+
+    // The GraphQL variables template — an arbitrary JSON/YAML object containing
+    // `${...}` placeholders that get substituted at runtime.
+    pub variables: Option<JsonValue>,
+}
+
+// The `auth:` section of the config.
+// Supports two types matching the YAML config files in `scripts/`:
+//   "raw_cookie"      — full Cookie header pasted from Burp/DevTools
+//   "basic_api_token" — Atlassian API token (email + token file)
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AuthConfig {
+    // YAML key is `type` — a reserved word in Rust, so we rename it.
+    #[serde(rename = "type", default = "default_auth_type")]
+    pub auth_type: String,
+
+    // --- raw_cookie ---
+    // The full Cookie header value, either inline or from a file.
+    pub raw_cookie: Option<String>,
+    pub raw_cookie_file: Option<String>,
+
+    // --- basic_api_token ---
+    // Email is not a secret — it's inline in the config.
+    // API token is a secret — read from inline value or a file.
+    pub email: Option<String>,
+    pub api_token: Option<String>,
+    pub api_token_file: Option<String>,
+}
+
+fn default_auth_type() -> String {
+    "raw_cookie".to_string()
+}
+
+// The `confluence:` section of the config.
+// `#[derive(Clone)]` — needed because we clone it when building the template context.
+// `Serialize` — needed so `serde_json::to_value(config)` includes this struct.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ConfluenceConfig {
+    pub cloud_id: Option<String>,
+    pub account_id: Option<String>,
+    pub content_id: Option<String>,
+    pub space_key: Option<String>,
+    pub space_id: Option<String>,
+    pub installation_id: Option<String>,
+    pub environment_id: Option<String>,
+    pub environment_type: Option<String>,
+    pub local_id: Option<String>,
+    pub module_key: Option<String>,
+    pub site_url: Option<String>,
+    // Named Forge environment slot; used to look up environment_id when it
+    // isn't supplied explicitly. Defaults to "development".
+    pub environment_key: Option<String>,
+}
+
+// The `global:` section of the config — used when product: global.
+// Mirrors the fields needed to build a GlobalAppSignForgeContextTokensInput.
+//
+// `environment_id` is optional: if omitted, it is resolved automatically from
+// the Forge platform via `fetch_app_environment()` (see below), using the app
+// id (from the manifest) and `environment_key` (defaults to "development").
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct GlobalAppConfig {
+    pub cloud_id: Option<String>,
+    pub installation_id: Option<String>,
+    pub environment_id: Option<String>,
+    pub environment_type: Option<String>,
+    pub module_key: Option<String>,
+    // Named Forge environment slot ("development" | "staging" | "production").
+    // Used to look up environment_id when it isn't supplied explicitly.
+    pub environment_key: Option<String>,
+}
+
+// ============================================================================
+// Manifest context
+// ============================================================================
+// What we extract from the Forge app's manifest.yml.
+// Used to fill `${manifest.app_id_bare}`, `${manifest.module_key}`, etc.
+
+#[derive(Debug, Clone)]
+pub struct ManifestContext {
+    // Full ARI: "ari:cloud:ecosystem::app/8bdd65d0-..."
+    pub app_id: String,
+    // Bare UUID after the last "/": "8bdd65d0-..."
+    pub app_id_bare: String,
+    pub app_name: Option<String>,
+    pub module_key: Option<String>,
+    pub module_type: Option<String>,
+    // Resolved from the Forge platform via fetch_app_environment().
+    // environment_id: the UUID of the named environment slot.
+    // app_version: the latest deployed version string (e.g. "43.0.0").
+    // Both are None until the lookup runs; the default variable templates
+    // reference them as ${manifest.environment_id} and ${manifest.app_version}.
+    pub environment_id: Option<String>,
+    pub app_version: Option<String>,
+}
+
+// ============================================================================
+// extract_manifest_context()
+// ============================================================================
+// Reads a parsed ForgeManifest and returns a ManifestContext.
+//
+// Module/remote detection lives in forge_loader (see ForgeModules methods), so
+// this works entirely off the typed manifest — the manifest is read from disk
+// once and parsed once by the caller.
+// Resolve the module that owns a `--function` value, tolerating both the bare
+// "<function>" form and the "<resolver>.<function>" form. Tries the whole
+// string first, then the segment after the last '.'.
+fn detect_module_for_function<'a>(
+    manifest: &ForgeManifest<'a>,
+    function: &str,
+) -> Option<(&'a str, &'static str)> {
+    manifest
+        .modules
+        .detect_fct_module_for_function(function)
+        .or_else(|| {
+            function
+                .rsplit_once('.')
+                .and_then(|(_, tail)| manifest.modules.detect_fct_module_for_function(tail))
+        })
+}
+
+pub fn extract_manifest_context(
+    manifest: &ForgeManifest<'_>,
+    module_key: Option<&str>,
+) -> ManifestContext {
+    // No invoked function is known in the mint-only paths, so module selection
+    // uses first-module auto-detection (historical behaviour). With no
+    // function supplied, the function-aware error path cannot trigger, so the
+    // Result is always Ok here.
+    extract_manifest_context_for_function(manifest, module_key, None)
+        .expect("extract_manifest_context_for_function cannot fail without a function")
+}
+
+/// Like [`extract_manifest_context`], but aware of the backend resolver
+/// `function` being invoked.
+///
+/// Module selection precedence:
+///   1. An explicit `module_key` (from config) always wins. If it does not own
+///      the invoked `function`, a warning is emitted — the mismatch is usually a
+///      config mistake and would otherwise fail confusingly at the remote hop.
+///   2. Otherwise, if a `function` is supplied, select the module whose
+///      `resolver.function` matches it. This is the correct choice for apps
+///      where several modules share one resolver, or where the first-declared
+///      module is endpoint-backed (so blind first-module detection picks a
+///      `moduleKey` that does not match the invoked resolver). If no module
+///      declares that function, this is a hard error — we do NOT fall back to
+///      an unrelated module, because sending a mismatched `moduleKey` fails
+///      confusingly at the remote hop (e.g. a 404 text/html from the backend).
+///   3. Otherwise (no function supplied), fall back to first-module
+///      auto-detection.
+pub fn extract_manifest_context_for_function(
+    manifest: &ForgeManifest<'_>,
+    module_key: Option<&str>,
+    function: Option<&str>,
+) -> Result<ManifestContext> {
+    let app_id = manifest.app.id.to_string();
+
+    // Strip the ARI prefix to get the bare UUID.
+    // "ari:cloud:ecosystem::app/8bdd65d0-..." → "8bdd65d0-..."
+    let app_id_bare = app_id.rsplit('/').next().unwrap_or(&app_id).to_string();
+
+    let app_name = manifest.app.name.map(|s| s.to_string());
+
+    let (detected_key, detected_type) = match module_key {
+        // 1. Explicit override from config — inferring its type from the
+        //    manifest. Warn if it doesn't own the invoked function.
+        Some(key) => {
+            if let Some(func) = function {
+                let owns_func = detect_module_for_function(manifest, func)
+                    .is_some_and(|(matched_key, _)| matched_key == key);
+                if !owns_func {
+                    eprintln!(
+                        "warning: configured module_key '{key}' does not declare \
+                         resolver function '{func}'; the invocation's moduleKey may \
+                         not match the invoked resolver."
+                    );
+                }
+            }
+            (
+                Some(key.to_string()),
+                manifest
+                    .modules
+                    .fct_module_type_for_key(key)
+                    .map(|t| t.to_string()),
+            )
+        }
+        // 2. Select the module that owns the invoked function. No fallback: a
+        //    mismatched moduleKey fails confusingly downstream, so error out.
+        None => match function {
+            Some(func) => match detect_module_for_function(manifest, func) {
+                Some((key, module_type)) => (Some(key.to_string()), Some(module_type.to_string())),
+                None => {
+                    return Err(MintError::Config(format!(
+                        "no module in the manifest declares resolver function '{func}'. \
+                         Check the --function value, or set module_key in the config to \
+                         the module that owns this resolver."
+                    )));
+                }
+            },
+            // 3. No function supplied — first-module auto-detection.
+            None => match manifest.modules.detect_fct_module() {
+                Some((key, module_type)) => (Some(key.to_string()), Some(module_type.to_string())),
+                None => (None, None),
+            },
+        },
+    };
+
+    Ok(ManifestContext {
+        app_id,
+        app_id_bare,
+        app_name,
+        module_key: detected_key,
+        module_type: detected_type,
+        // Filled in later by resolve_environment() if a lookup runs.
+        environment_id: None,
+        app_version: None,
+    })
+}
+
+// ============================================================================
+// detect_remote_key()
+// ============================================================================
+// Walks the raw YAML manifest to find the `key` of the first declared remote.
+//
+// A remote in manifest.yml looks like:
+//   remotes:
+//     - key: my-remote-backend
+//       baseUrl: https://my-backend.com
+//       auth:
+//         appUser: {}
+//
+// Returns None if no remotes are declared — the caller (run_mint_fit) will
+// return a clear error in that case.
+//
+// An optional `override_key` (from the config) takes priority over
+// auto-detection — needed for apps with multiple remotes.
+pub fn detect_remote_key(
+    manifest: &ForgeManifest<'_>,
+    override_key: Option<&str>,
+) -> Option<String> {
+    // Config override takes priority over auto-detection.
+    if let Some(key) = override_key
+        && !key.is_empty()
+    {
+        return Some(key.to_string());
+    }
+
+    // Otherwise take the key of the first declared remote from the typed
+    // manifest. Returns None if no remotes are declared or the first one has
+    // no key.
+    manifest
+        .remotes
+        .as_ref()?
+        .first()
+        .map(|remote| remote.key.clone())
+        .filter(|key| !key.is_empty())
+}
+
+// ============================================================================
+// load_secret_from_config()
+// ============================================================================
+// Reads a secret from one of two sources (in priority order):
+//   1. Inline value in the config (e.g. `raw_cookie: "eyJ..."`)
+//   2. A file path              (e.g. `raw_cookie_file: "./session-cookie.txt"`)
+pub fn load_secret_from_config(
+    inline: Option<&str>,
+    file_path: Option<&str>,
+) -> Result<Option<String>> {
+    // 1. Inline value takes highest priority.
+    if let Some(v) = inline
+        && !v.is_empty()
+    {
+        return Ok(Some(v.to_string()));
+    }
+
+    // 2. Read from a file.
+    if let Some(path) = file_path
+        && !path.is_empty()
+    {
+        let contents = fs::read_to_string(path).map_err(|e| {
+            MintError::Config(format!("Could not read secret file '{}': {}", path, e))
+        })?;
+        return Ok(Some(contents.trim().to_string()));
+    }
+
+    Ok(None)
+}
+
+// ============================================================================
+// build_auth_headers()
+// ============================================================================
+// Reads the `auth:` section of the config and returns the HTTP headers needed
+// to authenticate the request. Returns a HashMap<header_name, header_value>.
+pub fn build_auth_headers(auth: &AuthConfig) -> Result<HashMap<String, String>> {
+    let mut headers = HashMap::new();
+
+    println!("\n=== Auth material ===");
+    println!("WARNING: Do not paste this output into public tickets, logs, or chat.");
+
+    match auth.auth_type.as_str() {
+        // ------------------------------------------------------------------
+        // raw_cookie: the full Cookie header pasted from Burp/DevTools.
+        // e.g. "tenant.session.token=eyJ...; atlassian.xsrf.token=5748..."
+        // ------------------------------------------------------------------
+        "raw_cookie" => {
+            let raw = load_secret_from_config(
+                auth.raw_cookie.as_deref(),
+                auth.raw_cookie_file.as_deref(),
+            )?
+            .ok_or_else(|| {
+                MintError::Config(
+                    "auth.type=raw_cookie requires `raw_cookie` (inline) or `raw_cookie_file`"
+                        .into(),
+                )
+            })?;
+
+            // Only print the first 80 chars — never log a full session token.
+            println!("Cookie (first 80 chars): {}...", &raw[..raw.len().min(80)]);
+
+            // Check the session token's `exp` claim locally (no network call).
+            // If we can definitively tell it is expired, hard-fail here with
+            // actionable advice — sending a stale cookie only yields a confusing
+            // HTTP 401 later. If we cannot read an `exp` (non-standard cookie
+            // format), we do NOT block: check_cookie_expiry() prints a warning
+            // and we proceed, letting the server be the final authority.
+            if let Some(secs_ago) = cookie_expired_secs_ago(&raw) {
+                return Err(MintError::CookieExpired(format!(
+                    "Session cookie EXPIRED {} ago. Renew it (e.g. re-copy the \
+                     Cookie header from your browser/Burp into `raw_cookie` or \
+                     the file referenced by `raw_cookie_file`), then retry.",
+                    format_duration(secs_ago),
+                )));
+            }
+            check_cookie_expiry(&raw);
+
+            headers.insert("Cookie".to_string(), raw.trim().to_string());
+        }
+
+        // ------------------------------------------------------------------
+        // basic_api_token: Atlassian API token encoded as HTTP Basic auth.
+        // The gateway accepts base64("email:api_token") in the Authorization header.
+        // ------------------------------------------------------------------
+        "basic_api_token" => {
+            let email = auth
+                .email
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    MintError::Config(
+                        "auth.type=basic_api_token requires `email` in the config".into(),
+                    )
+                })?;
+
+            let token =
+                load_secret_from_config(auth.api_token.as_deref(), auth.api_token_file.as_deref())?
+                    .ok_or_else(|| {
+                        MintError::Config(
+                    "auth.type=basic_api_token requires `api_token` (inline) or `api_token_file`"
+                        .into(),
+                )
+                    })?;
+
+            // HTTP Basic auth: base64-encode "email:token"
+            let credentials = format!("{}:{}", email.trim(), token.trim());
+            let encoded = B64.encode(credentials.as_bytes());
+
+            println!("Basic auth email: {}", email.trim());
+            println!(
+                "Authorization: Basic {}... (truncated)",
+                &encoded[..encoded.len().min(20)]
+            );
+            headers.insert("Authorization".to_string(), format!("Basic {}", encoded));
+        }
+
+        other => {
+            return Err(MintError::Config(format!(
+                "Unsupported auth.type: '{}'. Valid types: raw_cookie, basic_api_token",
+                other
+            )));
+        }
+    }
+
+    Ok(headers)
+}
+
+// ============================================================================
+// Session-cookie expiry checking
+// ============================================================================
+// The raw cookie contains `tenant.session.token`, which is a JWT. Its `exp`
+// claim tells us exactly when the session dies — we can read it locally without
+// any network round-trip. These helpers extract that claim and print a status
+// message so an expired cookie is caught up front (rather than surfacing as an
+// opaque HTTP 401 mid-request).
+
+const SESSION_COOKIE_NAME: &str = "tenant.session.token";
+
+// Pull the `tenant.session.token` value out of a full Cookie header string.
+// The header looks like "name1=val1; tenant.session.token=eyJ...; name2=val2".
+// Falls back to treating the whole trimmed string as the token if no explicit
+// `name=` prefix is present (i.e. the file contains only the bare JWT).
+fn extract_session_token(raw_cookie: &str) -> Option<&str> {
+    for pair in raw_cookie.split(';') {
+        let pair = pair.trim();
+        if let Some(value) = pair.strip_prefix(&format!("{SESSION_COOKIE_NAME}=")) {
+            return Some(value);
+        }
+    }
+    // No "name=" pair matched. If the whole thing looks like a bare JWT
+    // (three dot-separated segments and no '='), use it directly.
+    let trimmed = raw_cookie.trim();
+    if !trimmed.contains('=') && trimmed.split('.').count() == 3 {
+        return Some(trimmed);
+    }
+    None
+}
+
+// Decode a JWT's `exp` (expiry) claim, in Unix seconds. Returns None if the
+// token isn't a well-formed JWT or has no numeric `exp`.
+fn decode_jwt_exp(token: &str) -> Option<i64> {
+    // JWT = header.payload.signature — the middle segment is the JSON payload.
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload_bytes = B64_URL.decode(payload_b64).ok()?;
+    let payload: JsonValue = serde_json::from_slice(&payload_bytes).ok()?;
+    payload.get("exp")?.as_i64()
+}
+
+// Format a duration in seconds as a short human string, e.g. "2h 5m", "3d 4h".
+fn format_duration(seconds: i64) -> String {
+    let seconds = seconds.abs();
+    let days = seconds / 86_400;
+    let hours = (seconds % 86_400) / 3_600;
+    let minutes = (seconds % 3_600) / 60;
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+// Definitive expiry check used to hard-fail before sending a stale cookie.
+// Returns Some(seconds_since_expiry) ONLY when the session token is present,
+// is a readable JWT, and its `exp` is in the past. Returns None when the
+// cookie is still valid OR when we cannot read an `exp` (non-standard format) —
+// i.e. "don't block unless we are sure it is expired".
+fn cookie_expired_secs_ago(raw_cookie: &str) -> Option<i64> {
+    let token = extract_session_token(raw_cookie)?;
+    let exp = decode_jwt_exp(token)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    (exp <= now).then_some(now - exp)
+}
+
+// Inspect the raw cookie's session token and print its expiry status. Returns
+// true if the token is present and not yet expired, false otherwise. Purely
+// informational — it does not block the request (the hard block lives in
+// build_auth_headers via cookie_expired_secs_ago).
+pub fn check_cookie_expiry(raw_cookie: &str) -> bool {
+    let Some(token) = extract_session_token(raw_cookie) else {
+        println!(
+            "WARNING: could not find '{SESSION_COOKIE_NAME}' in the cookie — \
+             cannot check expiry."
+        );
+        return false;
+    };
+
+    let Some(exp) = decode_jwt_exp(token) else {
+        println!(
+            "WARNING: could not read an `exp` claim from '{SESSION_COOKIE_NAME}' \
+             (not a JWT?) — cannot check expiry."
+        );
+        return false;
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    if exp <= now {
+        println!(
+            "WARNING: session cookie EXPIRED {} ago (exp={}). \
+             Renew it (e.g. re-run the session-cookie harvester) before minting.",
+            format_duration(now - exp),
+            exp,
+        );
+        false
+    } else {
+        println!(
+            "Session cookie valid — expires in {} (exp={}).",
+            format_duration(exp - now),
+            exp,
+        );
+        true
+    }
+}
+
+// ============================================================================
+// render_template() and helpers
+// ============================================================================
+// Walks a JSON value tree and replaces every "${dotted.path}" placeholder
+// with the value found at that path in the template context.
+
+pub fn render_template(value: &JsonValue, context: &JsonValue) -> JsonValue {
+    match value {
+        JsonValue::Object(map) => {
+            let rendered = map
+                .iter()
+                .map(|(k, v)| (k.clone(), render_template(v, context)))
+                .collect();
+            JsonValue::Object(rendered)
+        }
+        JsonValue::Array(arr) => {
+            JsonValue::Array(arr.iter().map(|v| render_template(v, context)).collect())
+        }
+        JsonValue::String(s) => render_string(s, context),
+        other => other.clone(),
+    }
+}
+
+fn render_string(s: &str, context: &JsonValue) -> JsonValue {
+    let re = Regex::new(r"\$\{([^}]+)\}").unwrap();
+
+    // If the entire string is a single placeholder, return the resolved value
+    // preserving its original type (number, boolean, etc.)
+    if let Some(caps) = re.captures(s)
+        && caps[0] == *s
+    {
+        let path = &caps[1];
+        return get_path(context, path).cloned().unwrap_or(JsonValue::Null);
+    }
+
+    // Otherwise replace each placeholder with its string representation.
+    let result = re.replace_all(s, |caps: &regex::Captures<'_>| {
+        let path = &caps[1];
+        match get_path(context, path) {
+            Some(JsonValue::String(v)) => v.clone(),
+            Some(JsonValue::Null) | None => String::new(),
+            Some(v) => v.to_string(),
+        }
+    });
+
+    JsonValue::String(result.into_owned())
+}
+
+// Walks a JsonValue by a dotted path string.
+// "config.confluence.cloud_id" → context["config"]["confluence"]["cloud_id"]
+pub fn get_path<'a>(context: &'a JsonValue, path: &str) -> Option<&'a JsonValue> {
+    let mut cur = context;
+    for part in path.split('.') {
+        cur = cur.get(part)?;
+    }
+    Some(cur)
+}
+
+// ============================================================================
+// post_graphql()
+// ============================================================================
+// Sends a GraphQL POST request to the Atlassian gateway and returns
+// (http_status_code, response_body_text).
+// This is the ONLY place in the codebase that uses `ureq`.
+pub fn post_graphql(
+    endpoint: &str,
+    operation_name: &str,
+    auth_headers: &HashMap<String, String>,
+    query: &str,
+    variables: &JsonValue,
+) -> Result<(u16, String)> {
+    // Extract origin from the endpoint URL for CSRF headers.
+    // "https://lhe2.atlassian.net/gateway/api/graphql" → "https://lhe2.atlassian.net"
+    let origin = endpoint.split('/').take(3).collect::<Vec<_>>().join("/");
+
+    // Append operation name as a query param — gateway uses this for routing.
+    let url = format!("{}?q={}", endpoint, operation_name);
+
+    let body = serde_json::json!({
+        "operationName": operation_name,
+        "query": query,
+        "variables": variables,
+    });
+
+    // Build the ureq POST request.
+    // `.set(name, value)` adds an HTTP header.
+    // `ureq::post(&url)` returns a request builder.
+    let mut request = ureq::post(&url)
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json")
+        .set("Origin", &origin)
+        .set("Referer", &format!("{}/", origin))
+        .set("X-Experimentalapi", "confluence-agg-beta")
+        .set("X-Apollo-Operation-Name", operation_name)
+        .set(
+            "User-Agent",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+             AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+        );
+
+    // Add auth headers (Cookie or Authorization).
+    for (name, value) in auth_headers {
+        request = request.set(name, value);
+    }
+
+    // `.send_json()` serialises the body and sends the request.
+    match request.send_json(&body) {
+        Ok(response) => {
+            let status = response.status();
+            let text = response
+                .into_string()
+                .map_err(|e| MintError::Http(e.to_string()))?;
+            Ok((status, text))
+        }
+        Err(ureq::Error::Status(code, response)) => {
+            // HTTP 4xx/5xx — still read the body for error details.
+            let text = response
+                .into_string()
+                .unwrap_or_else(|_| "<unreadable response body>".to_string());
+            Ok((code, text))
+        }
+        Err(e) => Err(MintError::Http(e.to_string())),
+    }
+}
+
+// ============================================================================
+// load_config()
+// ============================================================================
+// Loads and deserialises the `fsrt-remote.toml` config file into a
+// `MintFctConfig` using the `config` crate (config-rs).
+//
+// The `config` crate is a layered configuration system: sources are added in
+// priority order and merged, then the merged result is deserialised into a
+// typed struct via serde. Right now we use a single source — the TOML file —
+// but the builder pattern makes it trivial to add more layers later (e.g. an
+// `Environment` source so secrets like the session cookie can be supplied via
+// env vars instead of on disk):
+//
+//     Config::builder()
+//         .add_source(File::from(path))                       // fsrt-remote.toml
+//         .add_source(Environment::with_prefix("FSRT")        // FSRT_AUTH__RAW_COOKIE=...
+//             .separator("__"))
+//         .build()?
+//
+// `File::from(&Path)` auto-detects the format from the file extension, so a
+// `.toml` file is parsed as TOML. `try_deserialize()` then pours the merged
+// values into `MintFctConfig` — the exact same struct serde_yaml used to fill,
+// so all the `#[serde(...)]` attributes and downstream code are unchanged.
+pub fn load_config(config_path: &std::path::Path) -> Result<MintFctConfig> {
+    if !config_path.exists() {
+        return Err(MintError::Config(format!(
+            "Config file not found: {}",
+            config_path.display()
+        )));
+    }
+
+    let settings = config::Config::builder()
+        .add_source(config::File::from(config_path))
+        .build()?;
+
+    let cfg: MintFctConfig = settings.try_deserialize()?;
+    Ok(cfg)
+}
+
+// ============================================================================
+// fetch_app_environment() / resolve_environment()
+// ============================================================================
+// Resolves the app's environment_id (and latest deployed version) from the
+// Forge platform, so the pen tester doesn't have to paste a UUID or a version
+// string into the config.
+//
+// The query is app-scoped: given the app id (already read from manifest.yml)
+// and a named environment slot ("development" / "staging" / "production"), the
+// platform returns the environment UUID and the latest deployed version.
+//
+//   app(id: $appId) {
+//     environmentByKey(key: $envKey) { id }
+//     ...latest version...
+//   }
+
+// Default named environment slot when the config doesn't specify one.
+// The Forge platform's default development environment has the key "default"
+// (its `type` is DEVELOPMENT). Override via `environment_key` in the config.
+pub const DEFAULT_ENVIRONMENT_KEY: &str = "default";
+
+// The read query that resolves environment_id + latest app version.
+pub const APP_ENVIRONMENT_QUERY: &str = r#"query GetAppEnvironment($appId: ID!, $envKey: String!) {
+  app(id: $appId) {
+    id
+    name
+    environmentByKey(key: $envKey) {
+      id
+      key
+      type
+      versions {
+        nodes { version isLatest }
+      }
+    }
+  }
+}"#;
+pub const APP_ENVIRONMENT_OPERATION_NAME: &str = "GetAppEnvironment";
+
+// Result of the environment lookup.
+#[derive(Debug, Clone)]
+pub struct AppEnvironment {
+    pub environment_id: String,
+    // Latest deployed version, if the app has any deployed versions.
+    pub app_version: Option<String>,
+}
+
+// Performs the GraphQL query and parses out the environment id + version.
+// Reuses the shared post_graphql() helper — same endpoint, same auth headers.
+pub fn fetch_app_environment(
+    endpoint: &str,
+    auth_headers: &HashMap<String, String>,
+    app_id: &str,
+    env_key: &str,
+) -> Result<AppEnvironment> {
+    let variables = serde_json::json!({
+        "appId": app_id,
+        "envKey": env_key,
+    });
+
+    let (status, body) = post_graphql(
+        endpoint,
+        APP_ENVIRONMENT_OPERATION_NAME,
+        auth_headers,
+        APP_ENVIRONMENT_QUERY,
+        &variables,
+    )?;
+
+    let parsed: JsonValue = serde_json::from_str(&body).map_err(MintError::Json)?;
+
+    let env = parsed
+        .get("data")
+        .and_then(|d| d.get("app"))
+        .and_then(|a| a.get("environmentByKey"));
+
+    let environment_id = env
+        .and_then(|e| e.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            MintError::Config(format!(
+                "Could not resolve environment '{}' for app {} (HTTP {}). \
+                 Check the environment key, or set environment_id explicitly in the config.\n\
+                 Response body: {}",
+                env_key, app_id, status, body
+            ))
+        })?
+        .to_string();
+
+    // Version is best-effort — an app may have no deployed versions yet.
+    // Pick the node flagged isLatest, falling back to the first node.
+    let app_version = env
+        .and_then(|e| e.get("versions"))
+        .and_then(|v| v.get("nodes"))
+        .and_then(|n| n.as_array())
+        .and_then(|nodes| {
+            nodes
+                .iter()
+                .find(|node| {
+                    node.get("isLatest")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false)
+                })
+                .or_else(|| nodes.first())
+        })
+        .and_then(|node| node.get("version"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Ok(AppEnvironment {
+        environment_id,
+        app_version,
+    })
+}
+
+// High-level, opt-in resolver used by both subcommands.
+//
+// If the config already supplies `environment_id`, we trust it and skip the
+// network round-trip (the config value acts as an override/cache). Otherwise we
+// call fetch_app_environment() using the config's `environment_key` (defaulting
+// to "development") and populate manifest_ctx.environment_id + app_version so
+// build_variables() can reference them.
+pub fn resolve_environment(
+    config: &MintFctConfig,
+    manifest_ctx: &mut ManifestContext,
+    auth_headers: &HashMap<String, String>,
+) -> Result<()> {
+    // Read the config's explicit environment_id / environment_key for the
+    // active product, if any.
+    let (explicit_id, env_key) = match config.product {
+        Product::Confluence => {
+            let c = config.confluence.as_ref();
+            (
+                c.and_then(|c| c.environment_id.clone()),
+                c.and_then(|c| c.environment_key.clone()),
+            )
+        }
+        Product::Global => {
+            let g = config.global.as_ref();
+            (
+                g.and_then(|g| g.environment_id.clone()),
+                g.and_then(|g| g.environment_key.clone()),
+            )
+        }
+    };
+
+    // Explicit environment_id in the config short-circuits the lookup.
+    if let Some(id) = explicit_id {
+        manifest_ctx.environment_id = Some(id);
+        return Ok(());
+    }
+
+    let env_key = env_key.unwrap_or_else(|| DEFAULT_ENVIRONMENT_KEY.to_string());
+
+    println!(
+        "\n=== Resolving environment '{}' via Forge platform ===",
+        env_key
+    );
+    let app_env = fetch_app_environment(
+        &config.graphql_endpoint,
+        auth_headers,
+        &manifest_ctx.app_id,
+        &env_key,
+    )?;
+
+    println!("  environment_id: {}", app_env.environment_id);
+    println!("  app_version:    {:?}", app_env.app_version);
+
+    manifest_ctx.environment_id = Some(app_env.environment_id);
+    manifest_ctx.app_version = app_env.app_version;
+
+    Ok(())
+}
+
+// ============================================================================
+// load_manifest()
+// ============================================================================
+// Shared manifest loading logic — reads the manifest.yml (or .yaml) from an app
+// directory exactly once and returns its raw text.
+//
+// The returned String must be kept alive by the caller because the typed
+// `ForgeManifest` borrows from it. Callers parse it once via
+// `serde_yaml::from_str` — module/remote details are then read through the
+// typed accessors on `ForgeManifest`/`ForgeModules`, so the manifest is never
+// parsed a second time.
+pub fn load_manifest(app_dir: &Path) -> Result<String> {
+    let mut manifest_path = app_dir.join("manifest.yaml");
+    if !manifest_path.exists() {
+        manifest_path = app_dir.join("manifest.yml");
+    }
+    if !manifest_path.exists() {
+        return Err(MintError::Config(format!(
+            "Could not find manifest.yml or manifest.yaml in {}",
+            app_dir.display()
+        )));
+    }
+
+    Ok(fs::read_to_string(&manifest_path)?)
+}
+
+// ============================================================================
+// build_variables()
+// ============================================================================
+// Builds the final FCT GraphQL variables by rendering the template from the
+// config against the manifest + config context.
+// Branches on config.product to build the correct variable shape for each API.
+pub fn build_variables(
+    config: &MintFctConfig,
+    manifest_ctx: &ManifestContext,
+) -> Result<JsonValue> {
+    // Build the template context:
+    //   { "manifest": {...}, "config": <whole MintFctConfig as JSON> }
+    //
+    // This means ${config.confluence.cloud_id} and ${config.global.cloud_id}
+    // resolve correctly because MintFctConfig has both "confluence" and "global"
+    // fields that serde serialises by name.
+    let config_value =
+        serde_json::to_value(config).unwrap_or(JsonValue::Object(Default::default()));
+
+    let context = serde_json::json!({
+        "manifest": {
+            "app_id":         manifest_ctx.app_id,
+            "app_id_bare":    manifest_ctx.app_id_bare,
+            "app_name":       manifest_ctx.app_name,
+            "module_key":     manifest_ctx.module_key,
+            "module_type":    manifest_ctx.module_type,
+            // Resolved via resolve_environment() — used by the default templates
+            // so the pen tester never has to supply these.
+            "environment_id": manifest_ctx.environment_id,
+            "app_version":    manifest_ctx.app_version,
+        },
+        "config": config_value,
+    });
+
+    // Use the variables template from the config if supplied — works for both
+    // products. Otherwise fall back to a product-specific minimal default.
+    let template: JsonValue = if let Some(vars) = &config.variables {
+        vars.clone()
+    } else {
+        match config.product {
+            // NOTE: environment_id and app_version come from the resolved
+            // manifest context (${manifest.environment_id} / ${manifest.app_version}),
+            // not from the config — so the pen tester never supplies them.
+            Product::Confluence => serde_json::json!({
+                "cloudId": "${config.confluence.cloud_id}",
+                "input": {
+                    "contextIds": ["ari:cloud:confluence::site/${config.confluence.cloud_id}"],
+                    "extensionSpecificContexts": {
+                        "appVersion": "${manifest.app_version}",
+                        "extensionId": "ari:cloud:ecosystem::extension/${manifest.app_id_bare}/${manifest.environment_id}/static/${manifest.module_key}",
+                        "extensionType": "xen:macro",
+                        "installationId": "${config.confluence.installation_id}",
+                        "context": {
+                            // moduleKey is what the platform bakes into the signed
+                            // FCT and later surfaces as the resolver's
+                            // `context.moduleKey`. Resolvers that branch on it
+                            // (e.g. moduleKey.includes('node')) throw
+                            // "Cannot read properties of undefined" without it.
+                            "moduleKey": "${manifest.module_key}",
+                            "type": "${manifest.module_type}",
+                            "environmentId": "${manifest.environment_id}",
+                            "extension": { "type": "${manifest.module_type}" }
+                        }
+                    }
+                }
+            }),
+            Product::Global => serde_json::json!({
+                "input": {
+                    "contextIds": ["ari:cloud:jira::site/${config.global.cloud_id}"],
+                    "unlicensed": false,
+                    "extensionContexts": [{
+                        "appVersion": "${manifest.app_version}",
+                        "extensionId": "ari:cloud:ecosystem::extension/${manifest.app_id_bare}/${manifest.environment_id}/static/${manifest.module_key}",
+                        "extensionType": "xen:${manifest.module_type}",
+                        "installationId": "${config.global.installation_id}",
+                        "context": {
+                            // See the Confluence note above: moduleKey must be in
+                            // the signed FCT so the resolver's context.moduleKey
+                            // is populated.
+                            "moduleKey": "${manifest.module_key}",
+                            "cloudId": "${config.global.cloud_id}",
+                            "environmentId": "${manifest.environment_id}",
+                            "type": "${manifest.module_type}",
+                            "extension": { "type": "${manifest.module_type}" }
+                        }
+                    }]
+                }
+            }),
+        }
+    };
+
+    let rendered = render_template(&template, &context);
+
+    if !rendered.is_object() {
+        return Err(MintError::Config(
+            "Rendered GraphQL variables must be a JSON object".into(),
+        ));
+    }
+
+    Ok(rendered)
+}
+
+// ============================================================================
+// mint_fct_jwt()
+// ============================================================================
+// The core FCT minting function — called by both `mint_fct::run_mint_fct()`
+// and `mint_fit::run_mint_fit()`.
+//
+// Takes a fully-prepared config, manifest context, and auth headers, and
+// returns the FCT JWT string on success.
+//
+// This separation is why mint_common.rs exists — both subcommands need to
+// mint an FCT, but only mint_fct prints the result as the final output.
+// mint_fit uses the JWT as an input to the FIT minting step.
+pub fn mint_fct_jwt(
+    config: &MintFctConfig,
+    manifest_ctx: &ManifestContext,
+    auth_headers: &HashMap<String, String>,
+) -> Result<String> {
+    // Verbose by default — mint-fct / mint-fit want the full GraphQL trace.
+    mint_fct_jwt_opts(config, manifest_ctx, auth_headers, false)
+}
+
+// Same as `mint_fct_jwt`, but `quiet` suppresses the FCT GraphQL
+// variables/response diagnostics. `invoke-extension` uses quiet=true so its
+// output stays focused on the invocation, not the intermediate token mint.
+pub fn mint_fct_jwt_opts(
+    config: &MintFctConfig,
+    manifest_ctx: &ManifestContext,
+    auth_headers: &HashMap<String, String>,
+    quiet: bool,
+) -> Result<String> {
+    // Select mutation and operation name based on product.
+    let (default_mutation, operation_name, response_key) = match config.product {
+        Product::Confluence => (
+            DEFAULT_CONFLUENCE_MUTATION,
+            CONFLUENCE_OPERATION_NAME,
+            "confluence_generateForgeContextToken",
+        ),
+        Product::Global => (
+            DEFAULT_GLOBAL_APP_MUTATION,
+            GLOBAL_APP_OPERATION_NAME,
+            "globalApp_signForgeContextTokens",
+        ),
+    };
+
+    let query = config.mutation.as_deref().unwrap_or(default_mutation);
+
+    let variables = build_variables(config, manifest_ctx)?;
+
+    if !quiet {
+        println!("\n=== FCT GraphQL variables ===");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&variables)
+                .unwrap_or_else(|_| "<serialisation error>".to_string())
+        );
+    }
+
+    let (status, body) = post_graphql(
+        &config.graphql_endpoint,
+        operation_name,
+        auth_headers,
+        query,
+        &variables,
+    )?;
+
+    // Parse and (unless quiet) pretty-print the response.
+    let parsed: JsonValue = serde_json::from_str(&body).map_err(|e| {
+        println!("{}", body); // print raw body if not valid JSON
+        MintError::Json(e)
+    })?;
+    if !quiet {
+        println!("\n=== FCT GraphQL response ===");
+        println!("HTTP status: {}", status);
+        println!("{}", serde_json::to_string_pretty(&parsed)?);
+    }
+
+    // Navigate to the FCT JWT in the response tree using the product-specific key.
+    // Confluence: data.confluence_generateForgeContextToken.forgeContextToken.jwt
+    // Global:     data.globalApp_signForgeContextTokens.tokens[0].jwt
+    let fct_obj = parsed.get("data").and_then(|d| d.get(response_key));
+
+    let success = fct_obj
+        .and_then(|o| o.get("success"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if !success {
+        // Collect server-side error messages for a useful error.
+        let errors: Vec<&str> = fct_obj
+            .and_then(|o| o.get("errors"))
+            .and_then(|e| e.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        return Err(MintError::FctFailed(if errors.is_empty() {
+            "Server returned success=false with no error messages".to_string()
+        } else {
+            errors.join("; ")
+        }));
+    }
+
+    // Extract the JWT string — path differs by product:
+    //   Confluence: .forgeContextToken.jwt  (single object)
+    //   Global:     .tokens[0].jwt           (list, take first)
+    let jwt = match config.product {
+        Product::Confluence => fct_obj
+            .and_then(|o| o.get("forgeContextToken"))
+            .and_then(|t| t.get("jwt"))
+            .and_then(|j| j.as_str())
+            .ok_or_else(|| {
+                MintError::FctFailed("forgeContextToken.jwt missing from response".to_string())
+            })?,
+        Product::Global => fct_obj
+            .and_then(|o| o.get("tokens"))
+            .and_then(|t| t.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|t| t.get("jwt"))
+            .and_then(|j| j.as_str())
+            .ok_or_else(|| {
+                MintError::FctFailed("tokens[0].jwt missing from response".to_string())
+            })?,
+    };
+
+    Ok(jwt.to_string())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+// These cover the pure, network-free helpers shared by `mint_fct` and
+// `mint_fit`: dotted-path lookup, `${...}` template rendering, `Product`
+// display, and human-readable duration formatting. The GraphQL/HTTP paths are
+// intentionally not exercised here — they require a live Atlassian gateway.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn get_path_walks_nested_objects() {
+        let ctx = json!({
+            "config": { "confluence": { "cloud_id": "abc-123" } }
+        });
+        assert_eq!(
+            get_path(&ctx, "config.confluence.cloud_id"),
+            Some(&json!("abc-123"))
+        );
+    }
+
+    #[test]
+    fn get_path_returns_none_for_missing_key() {
+        let ctx = json!({ "config": { "confluence": {} } });
+        assert_eq!(get_path(&ctx, "config.confluence.missing"), None);
+        assert_eq!(get_path(&ctx, "nope.at.all"), None);
+    }
+
+    #[test]
+    fn render_whole_string_placeholder_preserves_type() {
+        // A string that is *only* a placeholder resolves to the underlying
+        // JSON value, keeping its original type (here: a number).
+        let ctx = json!({ "count": 7 });
+        let template = json!("${count}");
+        assert_eq!(render_template(&template, &ctx), json!(7));
+    }
+
+    #[test]
+    fn render_embedded_placeholder_produces_string() {
+        // A placeholder embedded in surrounding text is substituted as text.
+        let ctx = json!({ "name": "world" });
+        let template = json!("hello ${name}!");
+        assert_eq!(render_template(&template, &ctx), json!("hello world!"));
+    }
+
+    #[test]
+    fn render_missing_placeholder_becomes_empty_or_null() {
+        let ctx = json!({});
+        // Whole-string placeholder → Null.
+        assert_eq!(render_template(&json!("${gone}"), &ctx), json!(null));
+        // Embedded missing placeholder → empty replacement.
+        assert_eq!(render_template(&json!("a${gone}b"), &ctx), json!("ab"));
+    }
+
+    #[test]
+    fn render_recurses_into_objects_and_arrays() {
+        let ctx = json!({ "id": "X1", "n": 2 });
+        let template = json!({
+            "outer": { "inner": "${id}" },
+            "list": ["${n}", "lit"]
+        });
+        let expected = json!({
+            "outer": { "inner": "X1" },
+            "list": [2, "lit"]
+        });
+        assert_eq!(render_template(&template, &ctx), expected);
+    }
+
+    #[test]
+    fn product_display_matches_yaml_values() {
+        assert_eq!(Product::Confluence.to_string(), "confluence");
+        assert_eq!(Product::Global.to_string(), "global");
+    }
+
+    #[test]
+    fn format_duration_buckets() {
+        assert_eq!(format_duration(45), "45s");
+        assert_eq!(format_duration(3 * 60), "3m");
+        assert_eq!(format_duration(2 * 3600 + 5 * 60), "2h 5m");
+        assert_eq!(format_duration(3 * 86_400 + 4 * 3600), "3d 4h");
+        // Negative inputs are treated as their absolute value.
+        assert_eq!(format_duration(-45), "45s");
+    }
+}

--- a/crates/fsrt/src/mint_fct.rs
+++ b/crates/fsrt/src/mint_fct.rs
@@ -1,36 +1,16 @@
 //! Forge Context Token (FCT) minting — `fsrt mint-fct` subcommand.
 //!
-//! This is a Rust port of `scripts/mint_fct_spike.py`.
-//! All shared types and functions live in `mint_common`. This module contains
-//! only what is specific to the `mint-fct` subcommand:
-//!   - `MintFctArgs` — the CLI argument struct
-//!   - `run_mint_fct()` — the top-level entry point
+//! All shared types and functions live in `mint_common`.
 
-// ============================================================================
-// Imports
-// ============================================================================
-
-// Everything shared with mint_fit lives in mint_common.
-// `super::` means "the parent module" — in Rust's module tree, mint_fct and
-// mint_common are siblings under the same crate root (main.rs).
 use super::mint_common::{
     DEFAULT_CONFLUENCE_MUTATION, DEFAULT_GLOBAL_APP_MUTATION, Product, build_auth_headers,
     extract_manifest_context, load_config, load_manifest, mint_fct_jwt, resolve_environment,
 };
 
 use forge_loader::manifest::ForgeManifest;
+use tracing::{debug, info};
 
-// ============================================================================
 // CLI arguments
-// ============================================================================
-
-// `#[derive(Debug, clap::Args)]`:
-//   Debug      → printable for logging
-//   clap::Args → clap parses these fields from the CLI flags
-//
-// The user runs:
-//   fsrt mint-fct [--app-dir ./my-app] [--config ./cfg.toml] [--dry-run]
-//   (--app-dir defaults to ".", --config to "./fsrt-remote.toml")
 #[derive(Debug, clap::Args)]
 pub struct MintFctArgs {
     #[arg(
@@ -55,32 +35,27 @@ pub struct MintFctArgs {
         help = "OPTIONAL: print the request but do not call GraphQL.\nDefault: false."
     )]
     pub dry_run: bool,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "OPTIONAL: print diagnostic logs to stderr.\n\
+                The FORGE_LOG env var, if set, takes precedence.\nDefault: false."
+    )]
+    pub verbose: bool,
 }
 
-// ============================================================================
-// run_mint_fct()
-// ============================================================================
-// Top-level entry point for `fsrt mint-fct`.
-// Called from main.rs after clap parses the CLI arguments.
-//
 // Returns `Box<dyn std::error::Error>` so it can propagate both MintError
 // and any other errors (e.g. config parse errors) back to main().
 pub fn run_mint_fct(args: &MintFctArgs) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    // --- 1. Load and parse the TOML config file ---
-    // load_config() uses the `config` crate to read fsrt-remote.toml and
-    // deserialise it into MintFctConfig.
+    // Load and parse the TOML config file
     let config = load_config(&args.config)?;
 
-    // --- 2. Load manifest.yml ---
-    // load_manifest() reads the file exactly once and returns its raw text.
-    // We parse it a single time into a typed ForgeManifest (which borrows from
-    // manifest_text); all module details are read through typed accessors.
+    // Load manifest
     let manifest_text = load_manifest(&args.app_dir)?;
     let manifest: ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
 
-    // --- 3. Extract manifest context ---
-    // Use the module_key from the product-specific config section if provided,
-    // otherwise auto-detect from the manifest.
+    // Extract manifest context
     let config_module_key = match config.product {
         Product::Confluence => config
             .confluence
@@ -91,51 +66,49 @@ pub fn run_mint_fct(args: &MintFctArgs) -> std::result::Result<(), Box<dyn std::
 
     let mut manifest_ctx = extract_manifest_context(&manifest, config_module_key);
 
-    // --- 4. Build auth headers ---
-    let auth_headers = build_auth_headers(&config.auth)?;
-
-    // --- 4b. Resolve environment_id + app_version ---
-    // If the config didn't provide environment_id, look it up from the Forge
-    // platform (using environment_key, default "development"). This is a
-    // read-only query and populates manifest_ctx for build_variables().
-    resolve_environment(&config, &mut manifest_ctx, &auth_headers)?;
-
-    // --- 5. Print diagnostic info ---
-    println!("\n=== Product ===");
-    println!("  {}", config.product);
-    println!("\n=== Derived manifest context ===");
-    println!("  app_id:      {}", manifest_ctx.app_id);
-    println!("  app_id_bare: {}", manifest_ctx.app_id_bare);
-    println!("  app_name:    {:?}", manifest_ctx.app_name);
-    println!("  module_key:  {:?}", manifest_ctx.module_key);
-    println!("  module_type: {:?}", manifest_ctx.module_type);
-    println!("\n=== GraphQL endpoint ===");
-    println!("{}", config.graphql_endpoint);
-    println!("\n=== GraphQL mutation ===");
+    // Diagnostics go to stderr; only the JWT is written to stdout.
     let default_mutation = match config.product {
         Product::Confluence => DEFAULT_CONFLUENCE_MUTATION,
         Product::Global => DEFAULT_GLOBAL_APP_MUTATION,
     };
-    println!("{}", config.mutation.as_deref().unwrap_or(default_mutation));
+    info!(
+        product = %config.product,
+        app_id = %manifest_ctx.app_id,
+        app_id_bare = %manifest_ctx.app_id_bare,
+        app_name = ?manifest_ctx.app_name,
+        module_key = ?manifest_ctx.module_key,
+        module_type = ?manifest_ctx.module_type,
+        endpoint = %config.graphql_endpoint,
+        "derived manifest context"
+    );
+    debug!(
+        mutation = %config.mutation.as_deref().unwrap_or(default_mutation),
+        "FCT GraphQL mutation"
+    );
 
-    // --- 6. Dry-run exit ---
-    // Build and print variables for inspection, but don't send the request.
+    // Dry-run exit: render and log the variables for inspection without any
+    // network calls.
     if args.dry_run {
         let variables = super::mint_common::build_variables(&config, &manifest_ctx)?;
-        println!("\n=== GraphQL variables ===");
-        println!("{}", serde_json::to_string_pretty(&variables)?);
-        println!("\nDry run requested — not sending GraphQL request.");
+        info!(
+            variables = %serde_json::to_string_pretty(&variables)?,
+            "dry run requested — not sending GraphQL request"
+        );
         return Ok(());
     }
 
-    // --- 7. Mint the FCT ---
-    // mint_fct_jwt() does the POST and returns the JWT string, or an error.
-    // This same function is also called by run_mint_fit() in mint_fit.rs.
+    // Build auth headers
+    let auth_headers = build_auth_headers(&config.auth)?;
+
+    // Resolve environment_id + app_version (may hit the network)
+    resolve_environment(&config, &mut manifest_ctx, &auth_headers)?;
+
+    // Mint the FCT — does the POST and returns the JWT string, or an error.
     let jwt = mint_fct_jwt(&config, &manifest_ctx, &auth_headers)?;
 
-    // --- 8. Print success output ---
-    println!("\n=== SUCCESS: Forge Context Token ===");
-    println!("jwt: {}", jwt);
+    // The token is the command's result: print it to stdout only.
+    info!("successfully minted Forge Context Token");
+    println!("{}", jwt);
 
     Ok(())
 }

--- a/crates/fsrt/src/mint_fct.rs
+++ b/crates/fsrt/src/mint_fct.rs
@@ -1,0 +1,141 @@
+//! Forge Context Token (FCT) minting — `fsrt mint-fct` subcommand.
+//!
+//! This is a Rust port of `scripts/mint_fct_spike.py`.
+//! All shared types and functions live in `mint_common`. This module contains
+//! only what is specific to the `mint-fct` subcommand:
+//!   - `MintFctArgs` — the CLI argument struct
+//!   - `run_mint_fct()` — the top-level entry point
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+// Everything shared with mint_fit lives in mint_common.
+// `super::` means "the parent module" — in Rust's module tree, mint_fct and
+// mint_common are siblings under the same crate root (main.rs).
+use super::mint_common::{
+    DEFAULT_CONFLUENCE_MUTATION, DEFAULT_GLOBAL_APP_MUTATION, Product, build_auth_headers,
+    extract_manifest_context, load_config, load_manifest, mint_fct_jwt, resolve_environment,
+};
+
+use forge_loader::manifest::ForgeManifest;
+
+// ============================================================================
+// CLI arguments
+// ============================================================================
+
+// `#[derive(Debug, clap::Args)]`:
+//   Debug      → printable for logging
+//   clap::Args → clap parses these fields from the CLI flags
+//
+// The user runs:
+//   fsrt mint-fct [--app-dir ./my-app] [--config ./cfg.toml] [--dry-run]
+//   (--app-dir defaults to ".", --config to "./fsrt-remote.toml")
+#[derive(Debug, clap::Args)]
+pub struct MintFctArgs {
+    #[arg(
+        long,
+        value_hint = clap::ValueHint::DirPath,
+        default_value = ".",
+        help = "OPTIONAL: Forge app dir containing manifest.yml."
+    )]
+    pub app_dir: std::path::PathBuf,
+
+    #[arg(
+        long,
+        value_hint = clap::ValueHint::FilePath,
+        default_value = "./fsrt-remote.toml",
+        help = "OPTIONAL: config TOML path."
+    )]
+    pub config: std::path::PathBuf,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "OPTIONAL: print the request but do not call GraphQL.\nDefault: false."
+    )]
+    pub dry_run: bool,
+}
+
+// ============================================================================
+// run_mint_fct()
+// ============================================================================
+// Top-level entry point for `fsrt mint-fct`.
+// Called from main.rs after clap parses the CLI arguments.
+//
+// Returns `Box<dyn std::error::Error>` so it can propagate both MintError
+// and any other errors (e.g. config parse errors) back to main().
+pub fn run_mint_fct(args: &MintFctArgs) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // --- 1. Load and parse the TOML config file ---
+    // load_config() uses the `config` crate to read fsrt-remote.toml and
+    // deserialise it into MintFctConfig.
+    let config = load_config(&args.config)?;
+
+    // --- 2. Load manifest.yml ---
+    // load_manifest() reads the file exactly once and returns its raw text.
+    // We parse it a single time into a typed ForgeManifest (which borrows from
+    // manifest_text); all module details are read through typed accessors.
+    let manifest_text = load_manifest(&args.app_dir)?;
+    let manifest: ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
+
+    // --- 3. Extract manifest context ---
+    // Use the module_key from the product-specific config section if provided,
+    // otherwise auto-detect from the manifest.
+    let config_module_key = match config.product {
+        Product::Confluence => config
+            .confluence
+            .as_ref()
+            .and_then(|c| c.module_key.as_deref()),
+        Product::Global => config.global.as_ref().and_then(|g| g.module_key.as_deref()),
+    };
+
+    let mut manifest_ctx = extract_manifest_context(&manifest, config_module_key);
+
+    // --- 4. Build auth headers ---
+    let auth_headers = build_auth_headers(&config.auth)?;
+
+    // --- 4b. Resolve environment_id + app_version ---
+    // If the config didn't provide environment_id, look it up from the Forge
+    // platform (using environment_key, default "development"). This is a
+    // read-only query and populates manifest_ctx for build_variables().
+    resolve_environment(&config, &mut manifest_ctx, &auth_headers)?;
+
+    // --- 5. Print diagnostic info ---
+    println!("\n=== Product ===");
+    println!("  {}", config.product);
+    println!("\n=== Derived manifest context ===");
+    println!("  app_id:      {}", manifest_ctx.app_id);
+    println!("  app_id_bare: {}", manifest_ctx.app_id_bare);
+    println!("  app_name:    {:?}", manifest_ctx.app_name);
+    println!("  module_key:  {:?}", manifest_ctx.module_key);
+    println!("  module_type: {:?}", manifest_ctx.module_type);
+    println!("\n=== GraphQL endpoint ===");
+    println!("{}", config.graphql_endpoint);
+    println!("\n=== GraphQL mutation ===");
+    let default_mutation = match config.product {
+        Product::Confluence => DEFAULT_CONFLUENCE_MUTATION,
+        Product::Global => DEFAULT_GLOBAL_APP_MUTATION,
+    };
+    println!("{}", config.mutation.as_deref().unwrap_or(default_mutation));
+
+    // --- 6. Dry-run exit ---
+    // Build and print variables for inspection, but don't send the request.
+    if args.dry_run {
+        let variables = super::mint_common::build_variables(&config, &manifest_ctx)?;
+        println!("\n=== GraphQL variables ===");
+        println!("{}", serde_json::to_string_pretty(&variables)?);
+        println!("\nDry run requested — not sending GraphQL request.");
+        return Ok(());
+    }
+
+    // --- 7. Mint the FCT ---
+    // mint_fct_jwt() does the POST and returns the JWT string, or an error.
+    // This same function is also called by run_mint_fit() in mint_fit.rs.
+    let jwt = mint_fct_jwt(&config, &manifest_ctx, &auth_headers)?;
+
+    // --- 8. Print success output ---
+    println!("\n=== SUCCESS: Forge Context Token ===");
+    println!("jwt: {}", jwt);
+
+    Ok(())
+}

--- a/crates/fsrt/src/mint_fit.rs
+++ b/crates/fsrt/src/mint_fit.rs
@@ -1,20 +1,6 @@
 //! Forge Invocation Token (FIT) minting — `fsrt mint-fit` subcommand.
 //!
-//! A FIT (ForgeInvocationToken) signs a specific backend invocation.
-//! It is minted in two steps internally:
-//!   1. Mint an FCT (Forge Context Token) — proves the user can invoke the extension
-//!   2. Use the FCT to mint a FIT — signs the actual remote backend invocation
-//!
-//! The user only runs one command (--app-dir defaults to ".", --config to
-//! "./fsrt-remote.toml"):
-//!   fsrt mint-fit [--app-dir ./my-app] [--config ./cfg.toml]
-//!
 //! The FCT is minted internally and used as input to the FIT mutation.
-//! It is never written to disk.
-
-// ============================================================================
-// Imports
-// ============================================================================
 
 use super::mint_common::{
     MintError, Product, build_auth_headers, detect_remote_key, extract_manifest_context,
@@ -23,20 +9,9 @@ use super::mint_common::{
 
 use forge_loader::manifest::ForgeManifest;
 use serde_json::Value as JsonValue;
+use tracing::{info, warn};
 
-// ============================================================================
 // GraphQL mutation for FIT minting
-// ============================================================================
-//
-// `SignInvocationTokenForUIInput` fields:
-//   forgeContextToken: String!  — the FCT JWT minted in step 1
-//   remoteKey: String!          — identifies the remote backend in manifest.yml
-//
-// Return type `ForgeInvocationToken` fields:
-//   jwt: String!        — the actual Forge Invocation Token
-//   expiresAt: String!  — expiry in milliseconds since UNIX epoch
-// The return type is `SignInvocationTokenForUIResponse` which wraps a
-// `ForgeInvocationToken` object containing the jwt and expiresAt fields.
 const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvocationTokenForUIInput!) {
   signInvocationTokenForUI(input: $input) {
     forgeInvocationToken {
@@ -48,16 +23,7 @@ const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvo
 
 const FIT_OPERATION_NAME: &str = "SignInvocationTokenForUI";
 
-// ============================================================================
 // CLI arguments
-// ============================================================================
-//
-// Usage:
-//   fsrt mint-fit [--app-dir ./my-app] [--config ./cfg.toml] [--dry-run]
-//   (--app-dir defaults to ".", --config to "./fsrt-remote.toml")
-//
-// Same flags as mint-fct — same YAML config file, same app directory.
-// No --fct or --fct-file flag needed — the FCT is minted internally.
 #[derive(Debug, clap::Args)]
 pub struct MintFitArgs {
     #[arg(
@@ -82,29 +48,25 @@ pub struct MintFitArgs {
         help = "OPTIONAL: print the request but do not call GraphQL.\nDefault: false."
     )]
     pub dry_run: bool,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "OPTIONAL: print diagnostic logs to stderr.\n\
+                The FORGE_LOG env var, if set, takes precedence.\nDefault: false."
+    )]
+    pub verbose: bool,
 }
 
-// ============================================================================
-// run_mint_fit()
-// ============================================================================
-// Top-level entry point for `fsrt mint-fit`.
-// Called from main.rs after clap parses the CLI arguments.
 pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    // --- 1. Load and parse the TOML config file ---
-    // The same config format as mint-fct — same auth, same confluence IDs.
-    // load_config() uses the `config` crate to read fsrt-remote.toml.
+    // Load and parse the TOML config file
     let config = load_config(&args.config)?;
 
-    // --- 2. Load manifest.yml ---
-    // load_manifest() reads the file exactly once and returns its raw text,
-    // which is kept alive so ForgeManifest can borrow from it. We parse it a
-    // single time; module and remote details are read through typed accessors.
+    // Load manifest.yml
     let manifest_text = load_manifest(&args.app_dir)?;
     let manifest: ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
 
-    // --- 3. Extract manifest context ---
-    // module_key — for the FCT minting step (same as mint-fct)
-    // remote_key — for the FIT minting step (new — from manifest["remotes"][0]["key"])
+    // Extract manifest context
     let config_module_key = match config.product {
         Product::Confluence => config
             .confluence
@@ -115,14 +77,14 @@ pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::
 
     let mut manifest_ctx = extract_manifest_context(&manifest, config_module_key);
 
-    // detect_remote_key() reads the first remote's key from the typed manifest.
-    // Returns None if no remotes are declared — we error clearly in that case.
-    // An optional override in the config takes priority over auto-detection
-    // (useful for apps with multiple remotes).
-    let remote_key_override = config
-        .confluence
-        .as_ref()
-        .and_then(|c| c.module_key.as_deref()); // reuse module_key field for now
+    // Which remote the FIT targets, fall back to first remote in manifest.
+    let remote_key_override = match config.product {
+        Product::Confluence => config
+            .confluence
+            .as_ref()
+            .and_then(|c| c.remote_key.as_deref()),
+        Product::Global => config.global.as_ref().and_then(|g| g.remote_key.as_deref()),
+    };
 
     let remote_key = detect_remote_key(&manifest, remote_key_override).ok_or_else(|| {
         MintError::Config(
@@ -133,33 +95,28 @@ pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::
         )
     })?;
 
-    // --- 4. Print diagnostic info ---
-    println!("\n=== Derived manifest context ===");
-    println!("  app_id:      {}", manifest_ctx.app_id);
-    println!("  app_id_bare: {}", manifest_ctx.app_id_bare);
-    println!("  app_name:    {:?}", manifest_ctx.app_name);
-    println!("  module_key:  {:?}", manifest_ctx.module_key);
-    println!("  module_type: {:?}", manifest_ctx.module_type);
-    println!("  remote_key:  {}", remote_key);
-    println!("\n=== GraphQL endpoint ===");
-    println!("{}", config.graphql_endpoint);
+    // Auto-detection warning
+    if remote_key_override.is_none() {
+        warn!(
+            remote_key = %remote_key,
+            "no remote_key configured — targeting the first remote declared in the manifest"
+        );
+    }
 
-    // --- 5. Build auth headers ---
-    // Same auth headers for both the FCT and FIT requests —
-    // both go to the same Atlassian gateway with the same credentials.
-    let auth_headers = build_auth_headers(&config.auth)?;
+    // Diagnostics go to stderr; only the JWT is written to stdout.
+    info!(
+        app_id = %manifest_ctx.app_id,
+        app_id_bare = %manifest_ctx.app_id_bare,
+        app_name = ?manifest_ctx.app_name,
+        module_key = ?manifest_ctx.module_key,
+        module_type = ?manifest_ctx.module_type,
+        remote_key = %remote_key,
+        endpoint = %config.graphql_endpoint,
+        "derived manifest context"
+    );
 
-    // --- 5b. Resolve environment_id + app_version ---
-    // If the config didn't provide environment_id, look it up from the Forge
-    // platform (using environment_key, default "development"). Read-only query;
-    // populates manifest_ctx so the FCT step's build_variables() has real values.
-    resolve_environment(&config, &mut manifest_ctx, &auth_headers)?;
-
-    // --- 6. Dry-run exit ---
+    // Dry-run exit: log the request shape for inspection without any network calls.
     if args.dry_run {
-        println!("\n=== FIT GraphQL mutation ===");
-        println!("{}", FIT_MUTATION);
-        println!("\n=== FIT GraphQL variables (preview) ===");
         // We can't show the real FCT JWT without minting it, so show the shape.
         let preview_vars = serde_json::json!({
             "input": {
@@ -167,38 +124,36 @@ pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::
                 "remoteKey": remote_key,
             }
         });
-        println!("{}", serde_json::to_string_pretty(&preview_vars)?);
-        println!("\nDry run requested — not sending GraphQL request.");
+        info!(
+            mutation = %FIT_MUTATION,
+            variables = %serde_json::to_string_pretty(&preview_vars)?,
+            "dry run requested — not sending GraphQL request"
+        );
         return Ok(());
     }
 
-    // --- 7. Step 1: Mint the FCT ---
-    // mint_fct_jwt() lives in mint_common and is shared with mint_fct.rs.
-    // It sends the confluence_generateForgeContextToken mutation and returns
-    // the JWT string. The JWT is a local variable — never written to disk.
-    println!("\n=== Step 1: Minting FCT ===");
-    let fct_jwt = mint_fct_jwt(&config, &manifest_ctx, &auth_headers)?;
-    println!("FCT minted successfully.");
+    // Build auth headers
+    let auth_headers = build_auth_headers(&config.auth)?;
 
-    // --- 8. Step 2: Mint the FIT using the FCT ---
-    // Build the FIT mutation variables.
-    // `forgeContextToken` is the FCT JWT we just minted.
-    // `remoteKey` identifies which remote backend to sign the invocation for.
-    println!("\n=== Step 2: Minting FIT ===");
-    println!("FIT mutation: {}", FIT_OPERATION_NAME);
+    // Resolve environment_id + app_version (may hit the network)
+    resolve_environment(&config, &mut manifest_ctx, &auth_headers)?;
+
+    // Step 1: mint the FCT.
+    info!("step 1: minting FCT");
+    let fct_jwt = mint_fct_jwt(&config, &manifest_ctx, &auth_headers)?;
+    info!("FCT minted successfully");
+
+    // Step 2: mint the FIT using the FCT.
+    info!(operation = FIT_OPERATION_NAME, "step 2: minting FIT");
 
     let fit_variables = serde_json::json!({
         "input": {
-            "forgeContextToken": fct_jwt,   // ← the FCT JWT from step 1
-            "remoteKey": remote_key,         // ← from manifest["remotes"][0]["key"]
+            "forgeContextToken": fct_jwt,
+            "remoteKey": remote_key,
         }
     });
 
-    println!("\n=== FIT GraphQL variables ===");
-    println!("{}", serde_json::to_string_pretty(&fit_variables)?);
-
-    // Send the FIT minting request.
-    // post_graphql() is shared from mint_common — same function mint_fct uses.
+    // Send the FIT minting request
     let (status, body) = post_graphql(
         &config.graphql_endpoint,
         FIT_OPERATION_NAME,
@@ -207,15 +162,16 @@ pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::
         &fit_variables,
     )?;
 
-    println!("\n=== FIT GraphQL response ===");
-    println!("HTTP status: {}", status);
-
-    // Parse and pretty-print the response.
+    // Parse the response.
     let parsed: JsonValue = serde_json::from_str(&body).map_err(|e| {
-        println!("{}", body);
+        warn!(response_body = %body, "FIT response was not valid JSON");
         MintError::Json(e)
     })?;
-    println!("{}", serde_json::to_string_pretty(&parsed)?);
+    info!(
+        http_status = status,
+        response = %serde_json::to_string_pretty(&parsed).unwrap_or_default(),
+        "FIT GraphQL response"
+    );
 
     // Navigate to the FIT fields in the response.
     // data.signInvocationTokenForUI.forgeInvocationToken → { jwt, expiresAt }
@@ -224,42 +180,42 @@ pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::
         .and_then(|d| d.get("signInvocationTokenForUI"))
         .and_then(|r| r.get("forgeInvocationToken"));
 
-    match fit_obj {
-        Some(token) => {
-            let jwt = token.get("jwt").and_then(|v| v.as_str());
-            let expires_at = token.get("expiresAt").and_then(|v| v.as_str());
-
-            if let Some(jwt) = jwt {
-                println!("\n=== SUCCESS: Forge Invocation Token ===");
-                println!("jwt:       {}", jwt);
-                println!("expiresAt: {}", expires_at.unwrap_or("<missing>"));
+    if let Some(errors) = parsed.get("errors").and_then(|e| e.as_array())
+        && !errors.is_empty()
+    {
+        let messages: Vec<&str> = errors
+            .iter()
+            .filter_map(|err| err.get("message").and_then(|m| m.as_str()))
+            .collect();
+        return Err(MintError::FitFailed(format!(
+            "FIT minting failed: {}",
+            if messages.is_empty() {
+                "server returned errors with no messages".to_string()
             } else {
-                println!("\n[!] signInvocationTokenForUI returned but jwt field is missing.");
+                messages.join("; ")
             }
-        }
-        None => {
-            // Check for GraphQL-level errors.
-            if let Some(errors) = parsed.get("errors").and_then(|e| e.as_array()) {
-                println!("\n[!] Server returned errors:");
-                for err in errors {
-                    println!(
-                        "    - {}",
-                        err.get("message")
-                            .and_then(|m| m.as_str())
-                            .unwrap_or("(no message)")
-                    );
-                }
-                return Err(
-                    MintError::FctFailed("FIT minting failed — see errors above".into()).into(),
-                );
-            }
-            println!("\n[!] signInvocationTokenForUI missing from response data.");
-        }
+        ))
+        .into());
     }
 
-    if (200..300).contains(&(status as u32)) {
-        Ok(())
-    } else {
-        Err(MintError::Http(format!("Server returned HTTP {}", status)).into())
-    }
+    // Extract the JWT
+    let token = fit_obj.ok_or_else(|| {
+        MintError::FitFailed(
+            "signInvocationTokenForUI.forgeInvocationToken missing from response".into(),
+        )
+    })?;
+    let jwt = token.get("jwt").and_then(|v| v.as_str()).ok_or_else(|| {
+        MintError::FitFailed("forgeInvocationToken returned but `jwt` field is missing".into())
+    })?;
+    let expires_at = token
+        .get("expiresAt")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<missing>");
+
+    info!(expires_at, "successfully minted Forge Invocation Token");
+
+    // Print token to stdout
+    println!("{}", jwt);
+
+    Ok(())
 }

--- a/crates/fsrt/src/mint_fit.rs
+++ b/crates/fsrt/src/mint_fit.rs
@@ -1,0 +1,265 @@
+//! Forge Invocation Token (FIT) minting — `fsrt mint-fit` subcommand.
+//!
+//! A FIT (ForgeInvocationToken) signs a specific backend invocation.
+//! It is minted in two steps internally:
+//!   1. Mint an FCT (Forge Context Token) — proves the user can invoke the extension
+//!   2. Use the FCT to mint a FIT — signs the actual remote backend invocation
+//!
+//! The user only runs one command (--app-dir defaults to ".", --config to
+//! "./fsrt-remote.toml"):
+//!   fsrt mint-fit [--app-dir ./my-app] [--config ./cfg.toml]
+//!
+//! The FCT is minted internally and used as input to the FIT mutation.
+//! It is never written to disk.
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+use super::mint_common::{
+    MintError, Product, build_auth_headers, detect_remote_key, extract_manifest_context,
+    load_config, load_manifest, mint_fct_jwt, post_graphql, resolve_environment,
+};
+
+use forge_loader::manifest::ForgeManifest;
+use serde_json::Value as JsonValue;
+
+// ============================================================================
+// GraphQL mutation for FIT minting
+// ============================================================================
+//
+// `SignInvocationTokenForUIInput` fields:
+//   forgeContextToken: String!  — the FCT JWT minted in step 1
+//   remoteKey: String!          — identifies the remote backend in manifest.yml
+//
+// Return type `ForgeInvocationToken` fields:
+//   jwt: String!        — the actual Forge Invocation Token
+//   expiresAt: String!  — expiry in milliseconds since UNIX epoch
+// The return type is `SignInvocationTokenForUIResponse` which wraps a
+// `ForgeInvocationToken` object containing the jwt and expiresAt fields.
+const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvocationTokenForUIInput!) {
+  signInvocationTokenForUI(input: $input) {
+    forgeInvocationToken {
+      jwt
+      expiresAt
+    }
+  }
+}"#;
+
+const FIT_OPERATION_NAME: &str = "SignInvocationTokenForUI";
+
+// ============================================================================
+// CLI arguments
+// ============================================================================
+//
+// Usage:
+//   fsrt mint-fit [--app-dir ./my-app] [--config ./cfg.toml] [--dry-run]
+//   (--app-dir defaults to ".", --config to "./fsrt-remote.toml")
+//
+// Same flags as mint-fct — same YAML config file, same app directory.
+// No --fct or --fct-file flag needed — the FCT is minted internally.
+#[derive(Debug, clap::Args)]
+pub struct MintFitArgs {
+    #[arg(
+        long,
+        value_hint = clap::ValueHint::DirPath,
+        default_value = ".",
+        help = "OPTIONAL: Forge app dir containing manifest.yml."
+    )]
+    pub app_dir: std::path::PathBuf,
+
+    #[arg(
+        long,
+        value_hint = clap::ValueHint::FilePath,
+        default_value = "./fsrt-remote.toml",
+        help = "OPTIONAL: config TOML path."
+    )]
+    pub config: std::path::PathBuf,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "OPTIONAL: print the request but do not call GraphQL.\nDefault: false."
+    )]
+    pub dry_run: bool,
+}
+
+// ============================================================================
+// run_mint_fit()
+// ============================================================================
+// Top-level entry point for `fsrt mint-fit`.
+// Called from main.rs after clap parses the CLI arguments.
+pub fn run_mint_fit(args: &MintFitArgs) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // --- 1. Load and parse the TOML config file ---
+    // The same config format as mint-fct — same auth, same confluence IDs.
+    // load_config() uses the `config` crate to read fsrt-remote.toml.
+    let config = load_config(&args.config)?;
+
+    // --- 2. Load manifest.yml ---
+    // load_manifest() reads the file exactly once and returns its raw text,
+    // which is kept alive so ForgeManifest can borrow from it. We parse it a
+    // single time; module and remote details are read through typed accessors.
+    let manifest_text = load_manifest(&args.app_dir)?;
+    let manifest: ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
+
+    // --- 3. Extract manifest context ---
+    // module_key — for the FCT minting step (same as mint-fct)
+    // remote_key — for the FIT minting step (new — from manifest["remotes"][0]["key"])
+    let config_module_key = match config.product {
+        Product::Confluence => config
+            .confluence
+            .as_ref()
+            .and_then(|c| c.module_key.as_deref()),
+        Product::Global => config.global.as_ref().and_then(|g| g.module_key.as_deref()),
+    };
+
+    let mut manifest_ctx = extract_manifest_context(&manifest, config_module_key);
+
+    // detect_remote_key() reads the first remote's key from the typed manifest.
+    // Returns None if no remotes are declared — we error clearly in that case.
+    // An optional override in the config takes priority over auto-detection
+    // (useful for apps with multiple remotes).
+    let remote_key_override = config
+        .confluence
+        .as_ref()
+        .and_then(|c| c.module_key.as_deref()); // reuse module_key field for now
+
+    let remote_key = detect_remote_key(&manifest, remote_key_override).ok_or_else(|| {
+        MintError::Config(
+            "No remotes declared in manifest.yml. \
+             FIT minting requires a remote backend. \
+             Add a `remotes:` section with a `key:` field to your manifest."
+                .to_string(),
+        )
+    })?;
+
+    // --- 4. Print diagnostic info ---
+    println!("\n=== Derived manifest context ===");
+    println!("  app_id:      {}", manifest_ctx.app_id);
+    println!("  app_id_bare: {}", manifest_ctx.app_id_bare);
+    println!("  app_name:    {:?}", manifest_ctx.app_name);
+    println!("  module_key:  {:?}", manifest_ctx.module_key);
+    println!("  module_type: {:?}", manifest_ctx.module_type);
+    println!("  remote_key:  {}", remote_key);
+    println!("\n=== GraphQL endpoint ===");
+    println!("{}", config.graphql_endpoint);
+
+    // --- 5. Build auth headers ---
+    // Same auth headers for both the FCT and FIT requests —
+    // both go to the same Atlassian gateway with the same credentials.
+    let auth_headers = build_auth_headers(&config.auth)?;
+
+    // --- 5b. Resolve environment_id + app_version ---
+    // If the config didn't provide environment_id, look it up from the Forge
+    // platform (using environment_key, default "development"). Read-only query;
+    // populates manifest_ctx so the FCT step's build_variables() has real values.
+    resolve_environment(&config, &mut manifest_ctx, &auth_headers)?;
+
+    // --- 6. Dry-run exit ---
+    if args.dry_run {
+        println!("\n=== FIT GraphQL mutation ===");
+        println!("{}", FIT_MUTATION);
+        println!("\n=== FIT GraphQL variables (preview) ===");
+        // We can't show the real FCT JWT without minting it, so show the shape.
+        let preview_vars = serde_json::json!({
+            "input": {
+                "forgeContextToken": "<FCT JWT — minted at runtime>",
+                "remoteKey": remote_key,
+            }
+        });
+        println!("{}", serde_json::to_string_pretty(&preview_vars)?);
+        println!("\nDry run requested — not sending GraphQL request.");
+        return Ok(());
+    }
+
+    // --- 7. Step 1: Mint the FCT ---
+    // mint_fct_jwt() lives in mint_common and is shared with mint_fct.rs.
+    // It sends the confluence_generateForgeContextToken mutation and returns
+    // the JWT string. The JWT is a local variable — never written to disk.
+    println!("\n=== Step 1: Minting FCT ===");
+    let fct_jwt = mint_fct_jwt(&config, &manifest_ctx, &auth_headers)?;
+    println!("FCT minted successfully.");
+
+    // --- 8. Step 2: Mint the FIT using the FCT ---
+    // Build the FIT mutation variables.
+    // `forgeContextToken` is the FCT JWT we just minted.
+    // `remoteKey` identifies which remote backend to sign the invocation for.
+    println!("\n=== Step 2: Minting FIT ===");
+    println!("FIT mutation: {}", FIT_OPERATION_NAME);
+
+    let fit_variables = serde_json::json!({
+        "input": {
+            "forgeContextToken": fct_jwt,   // ← the FCT JWT from step 1
+            "remoteKey": remote_key,         // ← from manifest["remotes"][0]["key"]
+        }
+    });
+
+    println!("\n=== FIT GraphQL variables ===");
+    println!("{}", serde_json::to_string_pretty(&fit_variables)?);
+
+    // Send the FIT minting request.
+    // post_graphql() is shared from mint_common — same function mint_fct uses.
+    let (status, body) = post_graphql(
+        &config.graphql_endpoint,
+        FIT_OPERATION_NAME,
+        &auth_headers,
+        FIT_MUTATION,
+        &fit_variables,
+    )?;
+
+    println!("\n=== FIT GraphQL response ===");
+    println!("HTTP status: {}", status);
+
+    // Parse and pretty-print the response.
+    let parsed: JsonValue = serde_json::from_str(&body).map_err(|e| {
+        println!("{}", body);
+        MintError::Json(e)
+    })?;
+    println!("{}", serde_json::to_string_pretty(&parsed)?);
+
+    // Navigate to the FIT fields in the response.
+    // data.signInvocationTokenForUI.forgeInvocationToken → { jwt, expiresAt }
+    let fit_obj = parsed
+        .get("data")
+        .and_then(|d| d.get("signInvocationTokenForUI"))
+        .and_then(|r| r.get("forgeInvocationToken"));
+
+    match fit_obj {
+        Some(token) => {
+            let jwt = token.get("jwt").and_then(|v| v.as_str());
+            let expires_at = token.get("expiresAt").and_then(|v| v.as_str());
+
+            if let Some(jwt) = jwt {
+                println!("\n=== SUCCESS: Forge Invocation Token ===");
+                println!("jwt:       {}", jwt);
+                println!("expiresAt: {}", expires_at.unwrap_or("<missing>"));
+            } else {
+                println!("\n[!] signInvocationTokenForUI returned but jwt field is missing.");
+            }
+        }
+        None => {
+            // Check for GraphQL-level errors.
+            if let Some(errors) = parsed.get("errors").and_then(|e| e.as_array()) {
+                println!("\n[!] Server returned errors:");
+                for err in errors {
+                    println!(
+                        "    - {}",
+                        err.get("message")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or("(no message)")
+                    );
+                }
+                return Err(
+                    MintError::FctFailed("FIT minting failed — see errors above".into()).into(),
+                );
+            }
+            println!("\n[!] signInvocationTokenForUI missing from response data.");
+        }
+    }
+
+    if (200..300).contains(&(status as u32)) {
+        Ok(())
+    } else {
+        Err(MintError::Http(format!("Server returned HTTP {}", status)).into())
+    }
+}

--- a/fsrt-remote.toml
+++ b/fsrt-remote.toml
@@ -1,0 +1,62 @@
+# fsrt-remote.toml — shared config for all fsrt remote subcommands.
+#
+# --dry-run prints the rendered request without sending it
+#
+# WARNING: Output includes auth material (cookies/tokens).
+#
+# This is an EXAMPLE config. Replace every value below with your own; do not
+# commit real cookies, API tokens, tenant IDs, or account emails.
+#
+# ==============================================================================
+# Product selector — "confluence" or "global" (Jira, Compass, Rovo).
+# This decides which mutation is sent and which [section] below is read.
+# ==============================================================================
+product = "confluence"
+
+# Atlassian GraphQL gateway for the target site.
+graphql_endpoint = "https://YOUR-SITE.atlassian.net/gateway/api/graphql"
+
+# ==============================================================================
+# Auth
+# ==============================================================================
+# Switch methods by changing `type`. Secrets are read from local files (paths
+# below); change those files, not this config, so the config stays shareable.
+#
+[auth]
+# Option 1: Raw cookie (confirmed working for both products — ~30 day lifetime).
+# Capture the Cookie header from a live browser session via Burp/DevTools.
+type = "raw_cookie"
+raw_cookie_file = "./session-cookie.txt"
+#   Format of session-cookie.txt:
+#   tenant.session.token=eyJ...
+
+# Option 2: API token (working for Confluence only).
+# Generate at: https://id.atlassian.com/manage-profile/security/api-tokens
+# type = "basic_api_token"
+# email = "email-here@example.com"
+# api_token_file = "./api-token.txt"   # paste your API token into this file
+
+# ==============================================================================
+# IDs — fill in the section matching `product` above. The other is ignored.
+# Replace with the values for your installation.
+# ==============================================================================
+
+# Auto-resolved for whichever section is active:
+#   environment_id  — via the Forge platform (environmentByKey)
+#   environment_key — which slot to resolve; defaults to "default"
+#   module_key      — auto-detected from manifest.yml. mint-fct/fit pick the
+#                     first module. Set module_key below only to override this.
+
+# Used when product = "confluence"
+[confluence]
+cloud_id       = "00000000-0000-0000-0000-000000000000"  # curl https://YOUR-SITE.atlassian.net/_edge/tenant_info
+installation_id = "00000000-0000-0000-0000-000000000000" # forge install list --json → installationId (bare UUID)
+# environment_key = "default"
+# module_key = "hello-world-macro"   # override auto-detection (see note above)
+
+# Used when product = "global" (Jira, Compass, Rovo)
+[global]
+cloud_id       = "00000000-0000-0000-0000-000000000000"  # curl https://YOUR-SITE.atlassian.net/_edge/tenant_info
+installation_id = "00000000-0000-0000-0000-000000000000" # forge install list --json → installationId (bare UUID)
+# environment_key = "default"
+# module_key = "hello-jira-issue-panel"   # override auto-detection (see note above)

--- a/fsrt-remote.toml
+++ b/fsrt-remote.toml
@@ -26,7 +26,7 @@ graphql_endpoint = "https://YOUR-SITE.atlassian.net/gateway/api/graphql"
 # Option 1: Raw cookie (confirmed working for both products — ~30 day lifetime).
 # Capture the Cookie header from a live browser session via Burp/DevTools.
 type = "raw_cookie"
-raw_cookie_file = "./session-cookie.txt"
+raw_cookie_file = "./session-cookie.txt" # This session cookie storage will be changed to a more secure format in the future.
 #   Format of session-cookie.txt:
 #   tenant.session.token=eyJ...
 
@@ -46,6 +46,9 @@ raw_cookie_file = "./session-cookie.txt"
 #   environment_key — which slot to resolve; defaults to "default"
 #   module_key      — auto-detected from manifest.yml. mint-fct/fit pick the
 #                     first module. Set module_key below only to override this.
+#   remote_key      — which declared remote (manifest `remotes:` key) a FIT
+#                     targets. mint-fit defaults to the first remote; set
+#                     remote_key below only to override this.
 
 # Used when product = "confluence"
 [confluence]
@@ -53,6 +56,7 @@ cloud_id       = "00000000-0000-0000-0000-000000000000"  # curl https://YOUR-SIT
 installation_id = "00000000-0000-0000-0000-000000000000" # forge install list --json → installationId (bare UUID)
 # environment_key = "default"
 # module_key = "hello-world-macro"   # override auto-detection (see note above)
+# remote_key = "my-backend"          # which remote mint-fit targets
 
 # Used when product = "global" (Jira, Compass, Rovo)
 [global]
@@ -60,3 +64,4 @@ cloud_id       = "00000000-0000-0000-0000-000000000000"  # curl https://YOUR-SIT
 installation_id = "00000000-0000-0000-0000-000000000000" # forge install list --json → installationId (bare UUID)
 # environment_key = "default"
 # module_key = "hello-jira-issue-panel"   # override auto-detection (see note above)
+# remote_key = "my-backend"               # which remote mint-fit targets


### PR DESCRIPTION
## Add `mint-fct` and `mint-fit` commands for dynamic Forge testing

See [EAS-4556](https://asecurityteam.atlassian.net/browse/EAS-4556)

Adds two subcommands to mint Forge tokens against a live Atlassian site, for
dynamic testing of a Forge app's backend:

- **`mint-fct`** — mint a Forge Context Token (FCT).
- **`mint-fit`** — mint a Forge Invocation Token (FIT); mints an FCT first, then
  exchanges it.

Both read a TOML config (`fsrt-remote.toml`) + the app manifest, support Confluence and global (Jira/Compass/Rovo) apps, and authenticate via a raw session cookie or Basic API token.

### Notes for reviewers
- **Lean deps only:** `ureq`, `base64` (no feature gating needed).
- **Output matches FSRT convention:** diagnostics → stderr via `tracing`; only the
  JWT → stdout (pipeable). `--verbose` enables diagnostics (`--dry-run` implies it); `FORGE_LOG` still takes precedence.
- **`--dry-run` is fully offline** (no auth/network) for safe request inspection.
- **Config is example-only** — placeholders, no real secrets.
- Unit tests cover the pure helpers (template rendering, path lookup,`remote_key`/module detection).

### Follow-ups (not in this PR)
`invoke-extension` and `mint-cookie` (browser-based cookie harvesting, build on this foundation and will come in separate PRs.