### PR TITLE
feat: Update PAT check name, vuln grouping, and severity

### DIFF
--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -1079,8 +1079,8 @@ impl Checker<'_> for SecretChecker {
 
 #[derive(Debug, Clone)]
 pub enum AuthHeaderVulnKind {
-    BasicAuth,
-    BearerAdmin,
+    ApiToken,
+    ContainerToken,
 }
 
 #[derive(Debug)]
@@ -1160,22 +1160,20 @@ fn api_call_name(intrinsic: &Intrinsic) -> &'static str {
 impl fmt::Display for AuthHeaderVuln {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            AuthHeaderVulnKind::BasicAuth => {
+            AuthHeaderVulnKind::ApiToken => {
                 write!(
                     f,
-                    "HTTP Basic auth via {} ({})",
+                    "Atlassian API token via {} ({})",
                     self.api_call,
                     self.count()
                 )
             }
-            AuthHeaderVulnKind::BearerAdmin => {
-                write!(
-                    f,
-                    "Bearer token on admin API via {} ({})",
-                    self.api_call,
-                    self.count()
-                )
-            }
+            AuthHeaderVulnKind::ContainerToken => write!(
+                f,
+                "Atlassian container token via {} ({})",
+                self.api_call,
+                self.count()
+            ),
         }
     }
 }
@@ -1200,38 +1198,38 @@ impl IntoVuln for AuthHeaderVuln {
             .collect();
 
         match self.kind {
-            AuthHeaderVulnKind::BasicAuth => Vulnerability {
-                check_name: format!("Atlassian-Credential-Collection-Basic-Auth-{}", self.api_call),
+            AuthHeaderVulnKind::ApiToken => Vulnerability {
+                check_name: "Atlassian-API-Token".to_string(),
                 description: format!(
                     "Our API Token Scanner has identified in {} {} call(s) that your app is currently using Atlassian API tokens for authentication. Under the [updated guidance](https://www.atlassian.com/blog/developer/building-secure-and-scalable-integrations-our-guidance-for-third-party-apps) on app authentication ([FAQ](https://developer.atlassian.com/platform/marketplace/security-requirements-faq/#are-apps-prohibited-from-collecting-atlassian-user-account-api-tokens-even-after-taking-the-user-s-consent-) page) apps collecting customer API tokens are now required to migrate to [Forge authentication](https://developer.atlassian.com/platform/forge/security/#simple-and-secure-authentication) to ensure alignment with cloud app [security requirements](https://developer.atlassian.com/platform/marketplace/security-requirements/#security-requirements-for-cloud-apps). Refer to this [announcement](https://community.developer.atlassian.com/t/reminder-migrate-from-using-api-tokens-to-officially-supported-authentication-for-atlassian-apps-integrations/97221) for more details.",
                     count, self.api_call
                 ),
                 recommendation: "Use supported authentication mechanisms (such as OAuth 2.0 or Forge authentication). If you anticipate any blockers or require support, contact the Atlassian Ecosystem Support.",
                 proof: format!(
-                    "Basic Authorization header found: {}",
+                    "Atlassian API token Authorization header found: {}",
                     proof_lines.join("; ")
                 ),
-                severity: Severity::Medium,
+                severity: Severity::Critical,
                 app_key: reporter.app_key().to_owned(),
                 app_name: reporter.app_name().to_owned(),
-                marketplace_security_requirement: "Requirement 10",
+                marketplace_security_requirement: "Requirement 10.0",
                 date: reporter.current_date(),
             },
-            AuthHeaderVulnKind::BearerAdmin => Vulnerability {
-                check_name: "Atlassian-Credential-Collection-Bearer-Admin".to_string(),
+            AuthHeaderVulnKind::ContainerToken => Vulnerability {
+                check_name: "Atlassian-Container-Token".to_string(),
                 description: format!(
-                    "Our API Token Scanner has identified in {} {} call(s) that your app is currently using Atlassian API tokens for authentication. Under the [updated guidance](https://www.atlassian.com/blog/developer/building-secure-and-scalable-integrations-our-guidance-for-third-party-apps) on app authentication ([FAQ](https://developer.atlassian.com/platform/marketplace/security-requirements-faq/#are-apps-prohibited-from-collecting-atlassian-user-account-api-tokens-even-after-taking-the-user-s-consent-) page) apps collecting customer API tokens are now required to migrate to [Forge authentication](https://developer.atlassian.com/platform/forge/security/#simple-and-secure-authentication) to ensure alignment with cloud app [security requirements](https://developer.atlassian.com/platform/marketplace/security-requirements/#security-requirements-for-cloud-apps). Refer to this [announcement](https://community.developer.atlassian.com/t/reminder-migrate-from-using-api-tokens-to-officially-supported-authentication-for-atlassian-apps-integrations/97221) for more details.",
+                    "Our API Token Scanner has identified in {} {} call(s) that your app is currently using Atlassian container tokens for authentication to admin endpoints. Under the [updated guidance](https://www.atlassian.com/blog/developer/building-secure-and-scalable-integrations-our-guidance-for-third-party-apps) on app authentication ([FAQ](https://developer.atlassian.com/platform/marketplace/security-requirements-faq/#are-apps-prohibited-from-collecting-atlassian-user-account-api-tokens-even-after-taking-the-user-s-consent-) page) apps collecting customer tokens are now required to migrate to [Forge authentication](https://developer.atlassian.com/platform/forge/security/#simple-and-secure-authentication) to ensure alignment with cloud app [security requirements](https://developer.atlassian.com/platform/marketplace/security-requirements/#security-requirements-for-cloud-apps). Refer to this [announcement](https://community.developer.atlassian.com/t/reminder-migrate-from-using-api-tokens-to-officially-supported-authentication-for-atlassian-apps-integrations/97221) for more details.",
                     count, self.api_call
                 ),
                 recommendation: "Use supported authentication mechanisms (such as OAuth 2.0 or Forge authentication). If you anticipate any blockers or require support, contact the Atlassian Ecosystem Support.",
                 proof: format!(
-                    "Bearer token on Atlassian admin API found: {}",
+                    "Atlassian container token Authorization header found: {}",
                     proof_lines.join("; ")
                 ),
-                severity: Severity::Medium,
+                severity: Severity::Critical,
                 app_key: reporter.app_key().to_owned(),
                 app_name: reporter.app_name().to_owned(),
-                marketplace_security_requirement: "Requirement 10",
+                marketplace_security_requirement: "Requirement 10.0",
                 date: reporter.current_date(),
             },
         }
@@ -1322,14 +1320,14 @@ impl AuthHeaderChecker {
         let mut batched: Vec<AuthHeaderVuln> = Vec::new();
         for vuln in self.vulns {
             let kind_key: u8 = match vuln.kind {
-                AuthHeaderVulnKind::BasicAuth => 0,
-                AuthHeaderVulnKind::BearerAdmin => 1,
+                AuthHeaderVulnKind::ApiToken => 0,
+                AuthHeaderVulnKind::ContainerToken => 1,
             };
             // Find an existing batch with the same (kind, api_call) — group per app
             if let Some(existing) = batched.iter_mut().find(|b| {
                 let bk: u8 = match b.kind {
-                    AuthHeaderVulnKind::BasicAuth => 0,
-                    AuthHeaderVulnKind::BearerAdmin => 1,
+                    AuthHeaderVulnKind::ApiToken => 0,
+                    AuthHeaderVulnKind::ContainerToken => 1,
                 };
                 bk == kind_key && b.api_call == vuln.api_call
             }) {
@@ -1777,47 +1775,33 @@ impl<'cx> Runner<'cx> for AuthHeaderChecker {
                         _ => None,
                     };
 
-                    if let Some(scheme) = auth_scheme {
-                        match scheme {
-                            AuthScheme::Basic => {
-                                // Platform API shims (requestJira, requestConfluence,
-                                // requestBitbucket, requestGraph) always target
-                                // Atlassian APIs — their route operand is opaque
-                                // (tagged template) so URL resolution won't help.
-                                // For fetch / api.fetch / node-fetch the full URL
-                                // must target an Atlassian endpoint.
-                                let should_flag = is_platform_api
-                                    || url_str.as_deref().is_some_and(is_atlassian_url);
-                                if should_flag {
-                                    self.vulns.push(AuthHeaderVuln::new(
-                                        AuthHeaderVulnKind::BasicAuth,
-                                        api_call_name(intrinsic),
-                                        url_str.clone(),
-                                        interp.callstack(),
-                                        interp.env(),
-                                        interp.entry(),
-                                    ));
-                                }
-                            }
-                            AuthScheme::Bearer if is_fetch => {
-                                // BearerAdmin is only checked for fetch, not
-                                // platform API shims.
-                                let should_flag = url_str.as_deref().is_some_and(|s| {
-                                    (s.contains("api.atlassian.com") && s.contains("admin"))
-                                        || is_admin_path(s)
-                                });
-                                if should_flag {
-                                    self.vulns.push(AuthHeaderVuln::new(
-                                        AuthHeaderVulnKind::BearerAdmin,
-                                        api_call_name(intrinsic),
-                                        url_str.clone(),
-                                        interp.callstack(),
-                                        interp.env(),
-                                        interp.entry(),
-                                    ));
-                                }
-                            }
-                            _ => {}
+                    if let Some(scheme @ (AuthScheme::Basic | AuthScheme::Bearer)) = auth_scheme {
+                        // Platform API shims always target Atlassian APIs. For fetch /
+                        // api.fetch / node-fetch, require a recognized Atlassian URL.
+                        let should_flag = is_platform_api
+                            || (is_fetch
+                                && url_str.as_deref().is_some_and(|url| {
+                                    is_admin_path(url) || is_atlassian_url(url)
+                                }));
+
+                        if should_flag {
+                            // Container tokens are Bearer tokens used with admin endpoints.
+                            // Basic and non-admin Bearer tokens are reported as API tokens.
+                            let kind = if scheme == AuthScheme::Bearer
+                                && url_str.as_deref().is_some_and(is_admin_path)
+                            {
+                                AuthHeaderVulnKind::ContainerToken
+                            } else {
+                                AuthHeaderVulnKind::ApiToken
+                            };
+                            self.vulns.push(AuthHeaderVuln::new(
+                                kind,
+                                api_call_name(intrinsic),
+                                url_str.clone(),
+                                interp.callstack(),
+                                interp.env(),
+                                interp.entry(),
+                            ));
                         }
                     }
                 }

--- a/crates/forge_analyzer/src/ir.rs
+++ b/crates/forge_analyzer/src/ir.rs
@@ -1038,7 +1038,7 @@ impl fmt::Display for BasicBlock {
         for inst in &self.insts {
             writeln!(f, "    {inst}")?;
         }
-        write!(f, "    {}", &self.term)
+        write!(f, "    {}", self.term)
     }
 }
 

--- a/crates/fsrt/src/test.rs
+++ b/crates/fsrt/src/test.rs
@@ -26,9 +26,9 @@ trait ReportExt {
 
     fn contains_authz_vuln(&self, expected_len: usize) -> bool;
 
-    fn contains_basic_auth_vuln(&self, expected_len: usize) -> bool;
+    fn contains_api_token_vuln(&self, expected_len: usize) -> bool;
 
-    fn contains_bearer_admin_vuln(&self, expected_len: usize) -> bool;
+    fn contains_container_token_vuln(&self, expected_len: usize) -> bool;
 }
 
 impl ReportExt for Report {
@@ -47,19 +47,19 @@ impl ReportExt for Report {
     }
 
     #[inline]
-    fn contains_basic_auth_vuln(&self, expected_len: usize) -> bool {
+    fn contains_api_token_vuln(&self, expected_len: usize) -> bool {
         self.into_vulns()
             .iter()
-            .filter(|vuln| vuln.check_name().starts_with("Custom-Check-Basic-Auth-"))
+            .filter(|vuln| vuln.check_name() == "Atlassian-API-Token")
             .count()
             == expected_len
     }
 
     #[inline]
-    fn contains_bearer_admin_vuln(&self, expected_len: usize) -> bool {
+    fn contains_container_token_vuln(&self, expected_len: usize) -> bool {
         self.into_vulns()
             .iter()
-            .filter(|vuln| vuln.check_name().starts_with("Bearer-Admin"))
+            .filter(|vuln| vuln.check_name() == "Atlassian-Container-Token")
             .count()
             == expected_len
     }
@@ -695,12 +695,11 @@ fn secret_vuln_fetch_header() {
     assert!(scan_result.contains_vulns(1));
 }
 
-// Tests that Basic auth on a fetch to an Atlassian URL is detected across
-// several common import patterns: named import, default import (api.fetch),
-// chained .then(), and a pre-built template-literal header variable.
+// Tests that API tokens on a fetch to a non-admin Atlassian URL are detected
+// in both Basic and Bearer form across several common import patterns.
 #[test]
-fn basic_auth_fetch_detected_across_import_styles() {
-    // (source, expected_basic_auth_vulns)
+fn api_token_fetch_detected_across_import_styles() {
+    // (source, expected_api_token_vulns)
     let cases: &[(&str, usize)] = &[
         // named import { fetch }
         (
@@ -758,12 +757,25 @@ fn basic_auth_fetch_detected_across_import_styles() {
         export const run = render(<Macro app={<App />} />);",
             1,
         ),
+        // Bearer form on a non-admin Atlassian API is still an API token.
+        (
+            "// src/index.jsx
+        import ForgeUI, { render, Macro, Fragment, Text } from '@forge/ui';
+        import { fetch } from '@forge/api';
+        function App() {
+            let token = process.env.API_TOKEN;
+            fetch('api.atlassian.com/rest/api/3/issue', { headers: { Authorization: 'Bearer ' + token } });
+            return <Fragment><Text>Hello</Text></Fragment>;
+        }
+        export const run = render(<Macro app={<App />} />);",
+            1,
+        ),
     ];
 
     for (src, expected) in cases {
         let result = scan_directory_test(MockForgeProject::files_from_string(src));
         assert!(
-            result.contains_basic_auth_vuln(*expected),
+            result.contains_api_token_vuln(*expected),
             "expected {expected} basic-auth vuln(s) for snippet:\n{src}"
         );
         assert!(result.contains_secret_vuln(0));
@@ -804,7 +816,7 @@ fn fetch_http_basic_authorization_module_scope_headers() {
     );
 
     let scan_result = scan_directory_test(test_forge_project);
-    assert!(scan_result.contains_basic_auth_vuln(0));
+    assert!(scan_result.contains_api_token_vuln(0));
     assert!(scan_result.contains_secret_vuln(0));
     assert!(scan_result.contains_vulns(0));
 }
@@ -838,12 +850,12 @@ fn fetch_http_basic_authorization_module_scope_headers() {
 //     );
 
 //     let scan_result = scan_directory_test(test_forge_project);
-//     assert!(scan_result.contains_basic_auth_vuln(1));
+//     assert!(scan_result.contains_api_token_vuln(1));
 //     assert!(scan_result.contains_vulns(1));
 // }
 
 #[test]
-fn bearer_admin_api_fetch_static_url() {
+fn container_token_fetch_detected_for_bearer_admin_request() {
     let test_forge_project = MockForgeProject::files_from_string(
         "// src/index.jsx
         import ForgeUI, { render, Macro, Fragment, Text } from '@forge/ui';
@@ -857,19 +869,15 @@ fn bearer_admin_api_fetch_static_url() {
                     Accept: 'application/json'
                 }
             });
-            return (
-                <Fragment>
-                <Text>Hello</Text>
-                </Fragment>
-            );
+            return <Fragment><Text>Hello</Text></Fragment>;
         }
 
         export const run = render(<Macro app={<App />} />);",
     );
 
     let scan_result = scan_directory_test(test_forge_project);
-    assert!(scan_result.contains_bearer_admin_vuln(1));
-    assert!(scan_result.contains_basic_auth_vuln(0));
+    assert!(scan_result.contains_container_token_vuln(1));
+    assert!(scan_result.contains_api_token_vuln(0));
     assert!(scan_result.contains_vulns(1));
 }
 
@@ -903,17 +911,17 @@ fn bearer_admin_api_fetch_static_url() {
 //     );
 
 //     let scan_result = scan_directory_test(test_forge_project);
-//     assert!(scan_result.contains_bearer_admin_vuln(1));
-//     assert!(scan_result.contains_basic_auth_vuln(0));
+//     assert!(scan_result.contains_container_token_vuln(1));
+//     assert!(scan_result.contains_api_token_vuln(0));
 //     assert!(scan_result.contains_vulns(1));
 // }
 
 // Platform API shims (requestJira, requestConfluence, requestBitbucket) always
-// target Atlassian endpoints, so Basic auth on any of them is flagged regardless
-// of URL. Bearer auth on a shim is NOT flagged (only fetch is checked for BearerAdmin).
+// target non-admin Atlassian endpoints, so both Basic and Bearer forms are
+// reported as API tokens.
 #[test]
-fn basic_auth_on_platform_api_shims() {
-    // (label, source, expected_basic_auth, expected_bearer_admin)
+fn api_tokens_on_platform_api_shims() {
+    // (label, source, expected_api_token, expected_container_token)
     let cases: &[(&str, &str, usize, usize)] = &[
         (
             "requestJira concat",
@@ -986,31 +994,30 @@ fn basic_auth_on_platform_api_shims() {
             0,
         ),
         (
-            // Bearer on a platform shim must NOT be flagged as BearerAdmin
-            "bearer on requestJira not flagged",
+            "bearer on requestJira",
             "// src/index.jsx
         import ForgeUI, { render, Macro, Fragment, Text } from '@forge/ui';
         import api, { route } from '@forge/api';
         function App() {
-            let token = process.env.ADMIN_TOKEN;
+            let token = process.env.API_TOKEN;
             api.asApp().requestJira(route`/rest/api/3/issue`, { method: 'GET', headers: { Authorization: 'Bearer ' + token } });
             return <Fragment><Text>Hello</Text></Fragment>;
         }
         export const run = render(<Macro app={<App />} />);",
-            0,
+            1,
             0,
         ),
     ];
 
-    for (label, src, expected_basic, expected_bearer) in cases {
+    for (label, src, expected_api_token, expected_container_token) in cases {
         let result = scan_directory_test(MockForgeProject::files_from_string(src));
         assert!(
-            result.contains_basic_auth_vuln(*expected_basic),
-            "[{label}] expected {expected_basic} basic-auth vuln(s)"
+            result.contains_api_token_vuln(*expected_api_token),
+            "[{label}] expected {expected_api_token} API-token vuln(s)"
         );
         assert!(
-            result.contains_bearer_admin_vuln(*expected_bearer),
-            "[{label}] expected {expected_bearer} bearer-admin vuln(s)"
+            result.contains_container_token_vuln(*expected_container_token),
+            "[{label}] expected {expected_container_token} container-token vuln(s)"
         );
         assert!(
             result.contains_secret_vuln(0),
@@ -2298,7 +2305,7 @@ mod is_atlassian_url_tests {
 // Unit tests for `forge_analyzer::checkers::is_admin_path`.
 //
 // `is_admin_path` classifies URLs/paths that target Atlassian admin-scoped
-// endpoints. Bearer auth on a matching path is flagged as BearerAdmin.
+// endpoints. Bearer auth on a matching path is reported as a container token.
 // -----------------------------------------------------------------------------
 #[cfg(test)]
 mod is_admin_path_tests {


### PR DESCRIPTION
## Changes

- Replaced the previous Basic/Bearer finding names with:
  - `Atlassian-API-Token`
  - `Atlassian-Container-Token`
- Classifies a Bearer token as a container token when `is_admin_path` matches the request URL.
- Reports Basic tokens and non-admin Bearer tokens as API tokens.
- Updated vulnerability descriptions, proofs, and display names.
- Updated tests to assert the new check names and classification behavior.