### PR TITLE
mint-fct Environment Key Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,13 @@ The config is documented in [`fsrt-remote.toml.example`](fsrt-remote.toml.exampl
 `https://user.atlassian.net`, and is used to resolve `cloud_id`. GraphQL requests
 use `https://www.atlassian.net/gateway/api/graphql`.
 The installation ID, deployed environment, version, and extensions are discovered
-through GraphQL. Use `environment_key` to disambiguate when multiple environments are
-installed. `[auth].raw_cookie_file` is required. Relative cookie paths use the directory
-where FSRT is run, not the config file's directory. The cookie file contains
-authentication material and must not be committed.
+through GraphQL. When multiple installations are returned, `environment_key` selects
+one; without an override, FSRT prefers `production`, then `default`, then the first
+installation returned. If multiple installations match the selected environment, the
+first is used. The key is ignored when only one installation exists.
+`[auth].raw_cookie_file` is required. Relative cookie paths use the directory where FSRT
+is run, not the config file's directory. The cookie file contains authentication material
+and must not be committed.
 
 ## Tests
 

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 
 use forge_loader::manifest::ForgeManifest;
 use serde::Deserialize;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use ureq::Agent;
 
 use crate::app_config::{AppConfig, ExtensionConfig};
@@ -19,12 +19,12 @@ const DEFAULT_ENVIRONMENT_KEY: &str = "default";
 const APPS_OPERATION_NAME: &str = "Apps";
 const APPS_QUERY: &str = r#"query Apps(
   $ctx: ID!
-  $filters: [EcosystemAppsInstalledInContextsFilter!]
+  $appId: String!
 ) {
   ecosystem {
     appsInstalledInContexts(
       contextIds: [$ctx]
-      filters: $filters
+      filters: {type: ONLY_APP_IDS, values: [$appId]}
       options: {groupByBaseApp: true, shouldIncludePrivateApps: true}
     ) {
       edges {
@@ -209,20 +209,14 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             query: APPS_QUERY.to_string(),
             variables: serde_json::json!({
                 "ctx": &context_id,
-                "filters": [{
-                    "type": "ONLY_APP_IDS",
-                    "values": [&app_id]
-                }]
+                "appId": &app_id
             }),
         };
         let data: AppsData = post_graphql(&agent, &apps_request)?;
-        let (config, environment_id, environment_key) =
-            resolve_app_config(data, &context_id, &app_id, environment)?;
+        let config = resolve_app_config(data, &context_id, &app_id, environment)?;
         info!(
             product = ?product,
             app_id = ?app_id,
-            environment_id = ?environment_id,
-            environment_key = ?environment_key,
             extension_count = config.extensions.len(),
             installation_id = ?config.installation_id,
             "resolved installed app context"
@@ -340,7 +334,7 @@ fn resolve_app_config(
     context_id: &str,
     app_id: &str,
     environment: EnvironmentSelection,
-) -> Result<(AppConfig, String, String), MintError> {
+) -> Result<AppConfig, MintError> {
     let app = data
         .ecosystem
         .apps_installed_in_contexts
@@ -352,7 +346,7 @@ fn resolve_app_config(
             app_id: app_id.to_string(),
             context_id: context_id.to_string(),
         })?;
-    let installations = app.installations_by_contexts.nodes;
+    let mut installations = app.installations_by_contexts.nodes;
     let app_id_bare = app
         .id
         .strip_prefix("ari:cloud:ecosystem::app/")
@@ -366,46 +360,46 @@ fn resolve_app_config(
         });
     }
 
-    let selected_environment_key = match &environment {
-        EnvironmentSelection::Key(key) => Some(key.as_str()),
-        EnvironmentSelection::Automatic => [PRODUCTION_ENVIRONMENT_KEY, DEFAULT_ENVIRONMENT_KEY]
-            .into_iter()
-            .find(|key| {
-                installations
-                    .iter()
-                    .any(|installation| installation.app_environment.key == *key)
-            }),
-    };
-    let mut matches = installations
-        .into_iter()
-        .filter(|installation| {
-            selected_environment_key.is_none_or(|key| installation.app_environment.key == key)
-        })
-        .collect::<Vec<_>>();
-    if matches.len() > 1 {
-        return Err(MintError::AmbiguousInstallations {
-            environment_key: selected_environment_key.map(str::to_string),
-            installations: matches
-                .iter()
-                .map(|installation| installation.id.clone())
-                .collect(),
-        });
-    }
-
-    let Some(installation) = matches.pop() else {
-        return Err(match environment {
-            EnvironmentSelection::Key(environment_key) => MintError::EnvironmentNotFound {
-                environment_key,
-                app_id: app_id.to_string(),
-            },
-            EnvironmentSelection::Automatic => MintError::NoInstallations {
-                app_id: app_id.to_string(),
-                context_id: context_id.to_string(),
-            },
-        });
+    let installation = if installations.len() == 1 {
+        installations
+            .pop()
+            .expect("empty installations returned above")
+    } else {
+        let installation_count = installations.len();
+        let selected_environment_key = match &environment {
+            EnvironmentSelection::Key(key) => Some(key.as_str()),
+            EnvironmentSelection::Automatic => {
+                [PRODUCTION_ENVIRONMENT_KEY, DEFAULT_ENVIRONMENT_KEY]
+                    .into_iter()
+                    .find(|key| {
+                        installations
+                            .iter()
+                            .any(|installation| installation.app_environment.key == *key)
+                    })
+            }
+        };
+        let installation = match selected_environment_key {
+            Some(key) => installations
+                .into_iter()
+                .find(|installation| installation.app_environment.key == key)
+                .ok_or_else(|| MintError::EnvironmentNotFound {
+                    environment_key: key.to_string(),
+                    app_id: app_id.to_string(),
+                })?,
+            None => installations
+                .into_iter()
+                .next()
+                .expect("empty installations returned above"),
+        };
+        warn!(
+            installation_count,
+            selected_installation_id = %installation.id,
+            selected_environment_key = %installation.app_environment.key,
+            "multiple installations found; selecting first matching installation"
+        );
+        installation
     };
     let environment_id = installation.app_environment.id;
-    let environment_key = installation.app_environment.key;
     let version = installation.app_environment_version;
     let extensions = version
         .extensions
@@ -421,16 +415,12 @@ fn resolve_app_config(
             extension_type: extension.extension_type_key,
         })
         .collect();
-    Ok((
-        AppConfig {
-            context_id: context_id.to_string(),
-            app_version: version.version,
-            extensions,
-            installation_id: installation.id,
-        },
-        environment_id,
-        environment_key,
-    ))
+    Ok(AppConfig {
+        context_id: context_id.to_string(),
+        app_version: version.version,
+        extensions,
+        installation_id: installation.id,
+    })
 }
 
 #[cfg(test)]
@@ -553,10 +543,15 @@ mod tests {
         )
     }
 
-    fn installation(id: &str, environment: &str, module: &str) -> serde_json::Value {
+    fn installation(
+        id: &str,
+        environment_id: &str,
+        environment_key: &str,
+        module: &str,
+    ) -> serde_json::Value {
         serde_json::json!({
             "id": id,
-            "appEnvironment": { "envId": format!("env-{environment}"), "key": environment },
+            "appEnvironment": { "envId": environment_id, "key": environment_key },
             "appEnvironmentVersion": {
                 "version": "1.0.0",
                 "extensions": { "nodes": [{
@@ -585,13 +580,15 @@ mod tests {
             }
         }))
         .unwrap();
-        resolve_app_config(data, CONTEXT_ID, APP_ID, environment).map(|(config, _, _)| config)
+        resolve_app_config(data, CONTEXT_ID, APP_ID, environment)
     }
 
     #[test]
     fn app_query_response_drives_the_complete_mint_request() {
         for field in [
+            "$appId: String!",
             "appsInstalledInContexts(",
+            "filters: {type: ONLY_APP_IDS, values: [$appId]}",
             "installationsByContexts(contextIds: [$ctx])",
             "envId: id",
             "appEnvironmentVersion",
@@ -599,8 +596,14 @@ mod tests {
         ] {
             assert!(APPS_QUERY.contains(field), "query missing {field}");
         }
+        assert!(!APPS_QUERY.contains("$filters"));
         let config = resolve(
-            serde_json::json!([installation("installation-1", "production", "module-1")]),
+            serde_json::json!([installation(
+                "installation-1",
+                "environment-1",
+                "production",
+                "module-1"
+            )]),
             EnvironmentSelection::Automatic,
         )
         .unwrap();
@@ -617,7 +620,7 @@ mod tests {
                     "extensionContexts": [{
                         "appVersion": "1.0.0",
                         "context": {},
-                        "extensionId": "ari:cloud:ecosystem::extension/app-1/env-production/static/module-1",
+                        "extensionId": "ari:cloud:ecosystem::extension/app-1/environment-1/static/module-1",
                         "extensionType": "jira:issuePanel",
                         "installationId": "installation-1"
                     }]
@@ -646,14 +649,35 @@ mod tests {
     }
 
     #[test]
-    fn environment_selection_prefers_production_and_honors_an_override() {
+    fn environment_selection_is_only_used_for_multiple_installations() {
+        let config = resolve(
+            serde_json::json!([installation(
+                "installation-only",
+                "environment-development",
+                "development",
+                "module-only"
+            )]),
+            EnvironmentSelection::Key("staging".into()),
+        )
+        .unwrap();
+        assert_eq!(config.installation_id(), "installation-only");
+
         let installations = || {
             serde_json::json!([
-                installation("installation-default", "default", "default-module"),
-                installation("installation-production", "production", "production-module")
+                installation(
+                    "installation-default",
+                    "environment-default",
+                    "default",
+                    "default-module"
+                ),
+                installation(
+                    "installation-production",
+                    "environment-production",
+                    "production",
+                    "production-module"
+                )
             ])
         };
-
         for (selection, expected) in [
             (EnvironmentSelection::Automatic, "installation-production"),
             (
@@ -664,30 +688,73 @@ mod tests {
             let config = resolve(installations(), selection).unwrap();
             assert_eq!(config.installation_id(), expected);
         }
+
+        let config = resolve(
+            serde_json::json!([
+                installation(
+                    "installation-development",
+                    "environment-development",
+                    "development",
+                    "development-module"
+                ),
+                installation(
+                    "installation-staging",
+                    "environment-staging",
+                    "staging",
+                    "staging-module"
+                )
+            ]),
+            EnvironmentSelection::Automatic,
+        )
+        .unwrap();
+        assert_eq!(config.installation_id(), "installation-development");
+
+        let config = resolve(
+            serde_json::json!([
+                installation(
+                    "installation-production-first",
+                    "environment-production-first",
+                    "production",
+                    "production-module-first"
+                ),
+                installation(
+                    "installation-production-second",
+                    "environment-production-second",
+                    "production",
+                    "production-module-second"
+                )
+            ]),
+            EnvironmentSelection::Automatic,
+        )
+        .unwrap();
+        assert_eq!(config.installation_id(), "installation-production-first");
     }
 
     #[test]
-    fn app_query_selection_reports_missing_and_ambiguous_results() {
+    fn app_query_selection_reports_missing_results() {
         assert!(matches!(
             resolve(serde_json::json!([]), EnvironmentSelection::Automatic),
             Err(MintError::NoInstallations { .. })
         ));
         assert!(matches!(
             resolve(
-                serde_json::json!([installation("installation-1", "production", "module-1")]),
+                serde_json::json!([
+                    installation(
+                        "installation-1",
+                        "environment-production",
+                        "production",
+                        "module-1"
+                    ),
+                    installation(
+                        "installation-2",
+                        "environment-default",
+                        "default",
+                        "module-2"
+                    )
+                ]),
                 EnvironmentSelection::Key("staging".into())
             ),
             Err(MintError::EnvironmentNotFound { .. })
-        ));
-        assert!(matches!(
-            resolve(
-                serde_json::json!([
-                    installation("installation-1", "production", "module-1"),
-                    installation("installation-2", "production", "module-2")
-                ]),
-                EnvironmentSelection::Automatic
-            ),
-            Err(MintError::AmbiguousInstallations { .. })
         ));
     }
 

--- a/crates/forge_pen_test/src/fsrt_remote_config.rs
+++ b/crates/forge_pen_test/src/fsrt_remote_config.rs
@@ -21,7 +21,7 @@ pub struct FsrtRemoteConfig {
     /// Context ARI owner.
     pub product: String,
 
-    /// Optional Forge environment override.
+    /// Optional Forge environment preference used when multiple installations are found.
     pub environment_key: Option<String>,
 }
 

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -143,12 +143,6 @@ pub enum MintError {
         app_id: String,
     },
 
-    #[error("multiple installations matched environment {environment_key:?}: {installations:?}")]
-    AmbiguousInstallations {
-        environment_key: Option<String>,
-        installations: Vec<String>,
-    },
-
     #[error("module '{module_key}' not found; available: {available:?}")]
     ModuleKeyNotFound {
         module_key: String,

--- a/fsrt-remote.toml.example
+++ b/fsrt-remote.toml.example
@@ -6,7 +6,9 @@ site = "https://your-site.example.com"
 # Context ARI owner, such as "jira" or "confluence".
 product = "jira"
 
-# Override automatic production/default environment selection.
+# Used only to disambiguate when multiple app installations are returned.
+# Without an override, FSRT prefers "production", then "default", then the first result.
+# If multiple installations match, FSRT uses the first result.
 # environment_key = "production"
 
 # Authentication material. Do not commit this file.


### PR DESCRIPTION
The branch improves how mint-fct chooses a Forge app installation when GraphQL returns installations from multiple environments.
The resulting selection behavior is:

1. One installation: use it.
2. Explicit environment_key: use the first matching installation.
3. Automatic: use the first production, otherwise first default, otherwise the first returned installation.
4. Explicit key with no match still returns EnvironmentNotFound.