### PR TITLE
Mint FIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Arguments:
 
 Commands:
   mint-fct  Mint an FCT for a deployed module
+  mint-fit  Mint an FIT for a deployed module and Forge remote
 
   Options:
     -d, --debug
@@ -64,30 +65,21 @@ cargo install --git https://github.com/atlassian-labs/FSRT --locked
 
 ```text
 fsrt mint-fct <MODULE_KEY> [OPTIONS]
+fsrt mint-fit <MODULE_KEY> <REMOTE_KEY> [OPTIONS]
 ```
 
-For dynamic testing, `mint-fct` mints an FCT against a live Atlassian site.
-Invoke it before any scan directory arguments; use `--app-dir` to select the
-Forge app directory for this subcommand.
-It reads a TOML config (default `./fsrt-remote.toml`); see
-[`fsrt-remote.toml.example`](fsrt-remote.toml.example) for a commented example.
-Dry runs still authenticate and query deployment metadata, but skip token signing and
-print the exact GraphQL request that a live mint would send. Pass `--ctx '<JSON>'` to populate the selected extension's `context` object.
+Both commands use `--app-dir` and a TOML configuration file; see
+[`fsrt-remote.toml.example`](fsrt-remote.toml.example). Keep that configuration and its
+cookie file untracked.
 
-### Configuration
+`mint-fct` mints an FCT for a deployed module. `mint-fit` mints an FIT for a module and
+remote. For `mint-fct`, pass `--ctx '<JSON>'` to populate the selected extension's
+`context` object. For `mint-fit`, passing `--ctx` forces a new FCT with that context;
+otherwise `--fct`, a valid in-process cached FCT, or a newly minted FCT is used in that
+order.
 
-The config is documented in [`fsrt-remote.toml.example`](fsrt-remote.toml.example).
-`site` must be a full HTTPS origin without a path, such as
-`https://user.atlassian.net`, and is used to resolve `cloud_id`. GraphQL requests
-use `https://www.atlassian.net/gateway/api/graphql`.
-The installation ID, deployed environment, version, and extensions are discovered
-through GraphQL. When multiple installations are returned, `environment_key` selects
-one; without an override, FSRT prefers `production`, then `default`, then the first
-installation returned. If multiple installations match the selected environment, the
-first is used. The key is ignored when only one installation exists.
-`[auth].raw_cookie_file` is required. Relative cookie paths use the directory where FSRT
-is run, not the config file's directory. The cookie file contains authentication material
-and must not be committed.
+By default, live mint commands print only the token. `--dry-run` queries metadata without
+signing tokens. `--verbose` prints actual live diagnostics to stderr while keeping the minted token on stdout. Run `fsrt <COMMAND> --help` for all options.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cargo install --git https://github.com/atlassian-labs/FSRT --locked
 
 ```text
 fsrt mint-fct <MODULE_KEY> [OPTIONS]
-fsrt mint-fit <MODULE_KEY> <REMOTE_KEY> [OPTIONS]
+fsrt mint-fit [MODULE_KEY] <REMOTE_KEY> [OPTIONS]
 ```
 
 Both commands use `--app-dir` and a TOML configuration file; see
@@ -76,7 +76,7 @@ cookie file untracked.
 remote. For `mint-fct`, pass `--ctx '<JSON>'` to populate the selected extension's
 `context` object. For `mint-fit`, passing `--ctx` forces a new FCT with that context;
 otherwise `--fct`, a valid in-process cached FCT, or a newly minted FCT is used in that
-order.
+order. `MODULE_KEY` may be omitted when `--fct` supplies the FCT directly.
 
 By default, live mint commands print only the token. `--dry-run` queries metadata without
 signing tokens. `--verbose` prints actual live diagnostics to stderr while keeping the minted token on stdout. Run `fsrt <COMMAND> --help` for all options.

--- a/README.md
+++ b/README.md
@@ -65,18 +65,22 @@ cargo install --git https://github.com/atlassian-labs/FSRT --locked
 
 ```text
 fsrt mint-fct <MODULE_KEY> [OPTIONS]
-fsrt mint-fit [MODULE_KEY] <REMOTE_KEY> [OPTIONS]
+fsrt mint-fit <REMOTE_KEY> [--module <MODULE_KEY>] [OPTIONS]
 ```
 
 Both commands use `--app-dir` and a TOML configuration file; see
 [`fsrt-remote.toml.example`](fsrt-remote.toml.example). Keep that configuration and its
 cookie file untracked.
 
-`mint-fct` mints an FCT for a deployed module. `mint-fit` mints an FIT for a module and
-remote. For `mint-fct`, pass `--ctx '<JSON>'` to populate the selected extension's
-`context` object. For `mint-fit`, passing `--ctx` forces a new FCT with that context;
-otherwise the FCT supplied by `--fct` is used, or a new FCT with an empty context is
-minted. `MODULE_KEY` may be omitted when `--fct` supplies the FCT directly.
+`mint-fct` mints an FCT for a deployed module. Pass `--ctx '<JSON>'` to populate the
+selected extension's `context` object.
+
+`mint-fit` supports two mutually exclusive ways to provide its FCT:
+
+| Mode | Required inputs | Behavior |
+| --- | --- | --- |
+| Use an existing FCT | `<REMOTE_KEY> --fct <FCT>` | Uses the supplied FCT when `--module` and `--ctx` are omitted. |
+| Mint a new FCT | `<REMOTE_KEY> --module <MODULE_KEY>` | Mints an FCT with an empty context, then uses it to mint the FIT. Add `--ctx '<JSON>'` to set its context. |
 
 By default, live mint commands print only the token. `--dry-run` queries metadata without
 signing tokens. `--verbose` prints actual live diagnostics to stderr while keeping the minted token on stdout. Run `fsrt <COMMAND> --help` for all options.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ cookie file untracked.
 `mint-fct` mints an FCT for a deployed module. `mint-fit` mints an FIT for a module and
 remote. For `mint-fct`, pass `--ctx '<JSON>'` to populate the selected extension's
 `context` object. For `mint-fit`, passing `--ctx` forces a new FCT with that context;
-otherwise `--fct`, a valid in-process cached FCT, or a newly minted FCT is used in that
-order. `MODULE_KEY` may be omitted when `--fct` supplies the FCT directly.
+otherwise the FCT supplied by `--fct` is used, or a new FCT with an empty context is
+minted. `MODULE_KEY` may be omitted when `--fct` supplies the FCT directly.
 
 By default, live mint commands print only the token. `--dry-run` queries metadata without
 signing tokens. `--verbose` prints actual live diagnostics to stderr while keeping the minted token on stdout. Run `fsrt <COMMAND> --help` for all options.

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -498,6 +498,8 @@ where
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Remotes {
     #[serde(default)]
+    pub key: String,
+    #[serde(default)]
     pub auth: Value,
 }
 
@@ -1329,6 +1331,23 @@ mod tests {
 
         assert!(functions.next().unwrap().invokable);
         assert!(!functions.next().unwrap().invokable);
+    }
+
+    #[test]
+    fn test_remote_keys_are_deserialized_without_breaking_legacy_entries() {
+        let json = r#"{
+            "app": { "id": "my-app" },
+            "modules": {},
+            "remotes": [
+                { "key": "primary", "baseUrl": "https://example.com" },
+                { "baseUrl": "https://legacy.example.com" }
+            ]
+        }"#;
+        let manifest: ForgeManifest<'_> = serde_json::from_str(json).unwrap();
+        let remotes = manifest.remotes.unwrap();
+
+        assert_eq!(remotes[0].key, "primary");
+        assert_eq!(remotes[1].key, "");
     }
 
     // Test to check if Rovo modules can be deserialized properly from a sample manifest file.

--- a/crates/forge_pen_test/src/app_config.rs
+++ b/crates/forge_pen_test/src/app_config.rs
@@ -60,6 +60,21 @@ impl AppConfig {
         &self.extensions
     }
 
+    /// Returns the unique keys of the deployed Forge remote extensions.
+    pub fn remote_keys(&self) -> Vec<String> {
+        let mut remote_keys = self
+            .extensions
+            .iter()
+            .filter(|extension| extension.extension_type == "core:remote")
+            .filter(|extension| !extension.module_key.is_empty())
+            .map(|extension| extension.module_key.clone())
+            .collect::<Vec<_>>();
+        remote_keys.sort(); // why need to sort and dedup?
+        // make sure this only gets from the node you chose
+        remote_keys.dedup();
+        remote_keys
+    }
+
     /// Returns the first deployed extension whose key exactly matches `module_key`.
     pub fn extension_for_module_key(
         &self,
@@ -106,11 +121,19 @@ mod tests {
     use super::*;
 
     fn extension(module_key: &str, extension_id: &str) -> ExtensionConfig {
+        extension_with_type(module_key, extension_id, "jira:issuePanel")
+    }
+
+    fn extension_with_type(
+        module_key: &str,
+        extension_id: &str,
+        extension_type: &str,
+    ) -> ExtensionConfig {
         ExtensionConfig {
             module_key: module_key.into(),
             deployment_id: extension_id.into(),
             extension_id: extension_id.into(),
-            extension_type: "jira:issuePanel".into(),
+            extension_type: extension_type.into(),
         }
     }
 
@@ -162,6 +185,22 @@ mod tests {
                 .unwrap()
                 .extension_id(),
             "extension-1"
+        );
+    }
+
+    #[test]
+    fn remote_keys_only_include_unique_nonempty_core_remote_extensions() {
+        let config = config(vec![
+            extension_with_type("remote-b", "extension-1", "core:remote"),
+            extension_with_type("panel", "extension-2", "jira:issuePanel"),
+            extension_with_type("remote-a", "extension-3", "core:remote"),
+            extension_with_type("remote-b", "extension-4", "core:remote"),
+            extension_with_type("", "extension-5", "core:remote"),
+        ]);
+
+        assert_eq!(
+            config.remote_keys(),
+            vec!["remote-a".to_string(), "remote-b".to_string()]
         );
     }
 }

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -76,11 +76,11 @@ const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvo
   signInvocationTokenForUI(input: $input) {
     forgeInvocationToken {
       jwt
-      expiresAt
     }
   }
 }"#;
 const FIT_OPERATION_NAME: &str = "SignInvocationTokenForUI";
+const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum EnvironmentSelection {
@@ -166,11 +166,11 @@ struct FctData {
 struct FctResult {
     success: bool,
     errors: Vec<GraphqlErrorObject>,
-    tokens: Vec<FctToken>,
+    tokens: Vec<ForgeContextToken>,
 }
 
 #[derive(Debug, Deserialize)]
-struct FctToken {
+struct ForgeContextToken {
     jwt: String,
 }
 
@@ -186,24 +186,9 @@ struct FitResult {
     token: Option<ForgeInvocationToken>,
 }
 
-/// A minted Forge Invocation Token and its server-provided expiration.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct ForgeInvocationToken {
+#[derive(Debug, Deserialize)]
+struct ForgeInvocationToken {
     jwt: String,
-    #[serde(rename = "expiresAt")]
-    expires_at: String,
-}
-
-impl ForgeInvocationToken {
-    /// Returns the signed Forge Invocation Token JWT.
-    pub fn jwt(&self) -> &str {
-        &self.jwt
-    }
-
-    /// Returns the server-provided expiration value.
-    pub fn expires_at(&self) -> &str {
-        &self.expires_at
-    }
 }
 
 /// Reusable client for minting Forge Context and Invocation Tokens.
@@ -405,7 +390,7 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         remote_key: &str,
         context: Option<&serde_json::Value>,
         supplied_fct: Option<&str>,
-    ) -> Result<ForgeInvocationToken, MintError> {
+    ) -> Result<String, MintError> {
         let fct = if let Some(context) = context {
             let fct = self.mint_fct(module_key, context)?;
             info!(context = %context, "minted new Forge Context Token for FIT minting");
@@ -431,13 +416,21 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         };
 
         let request = self.mint_fit_request(module_key, &fct, remote_key)?;
+        let mut variables = request.variables.clone();
+        variables["input"]["forgeContextToken"] = REDACTED_FCT.into();
+        let variables = format!("{variables:#}");
+        info!(
+            operation_name = FIT_OPERATION_NAME,
+            variables = %variables,
+            "FIT GraphQL variables"
+        );
         let data: FitData = self.post_graphql_mutation(&request)?;
         let token = data
             .result
             .and_then(|result| result.token)
             .ok_or(MintError::MissingFitToken)?;
         debug!("successfully minted Forge Invocation Token");
-        Ok(token)
+        Ok(token.jwt)
     }
 }
 
@@ -563,53 +556,37 @@ mod tests {
     const APP_ID: &str = "ari:cloud:ecosystem::app/app-1";
     const CONTEXT_ID: &str = "ari:cloud:jira::site/cloud-1";
 
-    fn unix_time() -> i64 {
+    fn now() -> i64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64
     }
 
-    fn jwt_with_exp(exp: i64) -> String {
+    fn jwt(exp: i64) -> String {
         let header = URL_SAFE_NO_PAD.encode(serde_json::json!({ "alg": "RS256" }).to_string());
         let payload = URL_SAFE_NO_PAD.encode(serde_json::json!({ "exp": exp }).to_string());
-        let signature = URL_SAFE_NO_PAD.encode("signature");
-        format!("{header}.{payload}.{signature}")
-    }
-
-    fn extension(module_key: &str, suffix: &str, extension_type: &str) -> ExtensionConfig {
-        ExtensionConfig {
-            module_key: module_key.into(),
-            deployment_id: format!("extension-node-{suffix}"),
-            extension_id: format!(
-                "ari:cloud:ecosystem::extension/app-1/environment-1/static/{module_key}"
-            ),
-            extension_type: extension_type.into(),
-        }
+        format!("{header}.{payload}.{}", URL_SAFE_NO_PAD.encode("signature"))
     }
 
     fn tester() -> ForgePenTester<'static, 'static> {
         let manifest = Box::leak(Box::new(ForgeManifest {
-            remotes: Some(vec![
-                forge_loader::manifest::Remotes {
-                    key: "primary-remote".into(),
-                    auth: Default::default(),
-                },
-                forge_loader::manifest::Remotes {
-                    key: "secondary-remote".into(),
-                    auth: Default::default(),
-                },
-            ]),
+            remotes: Some(vec![forge_loader::manifest::Remotes {
+                key: "remote".into(),
+                ..Default::default()
+            }]),
             ..ForgeManifest::default()
         }));
         ForgePenTester {
             config: AppConfig {
                 context_id: CONTEXT_ID.into(),
                 app_version: "1.0.0".into(),
-                extensions: vec![
-                    extension("first-module", "1", "jira:issuePanel"),
-                    extension("second-module", "2", "xen:macro"),
-                ],
+                extensions: vec![ExtensionConfig {
+                    module_key: "module".into(),
+                    deployment_id: "deployment".into(),
+                    extension_id: "extension".into(),
+                    extension_type: "jira:issuePanel".into(),
+                }],
                 installation_id: "installation-1".into(),
             },
             agent: Agent::new_with_defaults(),
@@ -618,20 +595,18 @@ mod tests {
         }
     }
 
-    fn installation(
-        id: &str,
-        environment_id: &str,
-        environment_key: &str,
-        module: &str,
-    ) -> serde_json::Value {
+    fn installation(id: &str, environment: &str) -> serde_json::Value {
         serde_json::json!({
             "id": id,
-            "appEnvironment": { "envId": environment_id, "key": environment_key },
+            "appEnvironment": {
+                "envId": format!("{environment}-id"),
+                "key": environment
+            },
             "appEnvironmentVersion": {
                 "version": "1.0.0",
                 "extensions": { "nodes": [{
-                    "id": format!("deployment-{module}"),
-                    "key": module,
+                    "id": format!("{id}-deployment"),
+                    "key": format!("{id}-module"),
                     "extensionTypeKey": "jira:issuePanel"
                 }] }
             }
@@ -639,9 +614,13 @@ mod tests {
     }
 
     fn resolve(
-        installations: serde_json::Value,
+        installations: &[(&str, &str)],
         environment: EnvironmentSelection,
     ) -> Result<AppConfig, MintError> {
+        let installations = installations
+            .iter()
+            .map(|&(id, environment)| installation(id, environment))
+            .collect::<Vec<_>>();
         let data = serde_json::from_value(serde_json::json!({
             "ecosystem": {
                 "appsInstalledInContexts": {
@@ -658,181 +637,99 @@ mod tests {
         resolve_app_config(data, CONTEXT_ID, APP_ID, environment)
     }
 
+    fn selected(installations: &[(&str, &str)], environment: EnvironmentSelection) -> String {
+        resolve(installations, environment)
+            .unwrap()
+            .installation_id()
+            .into()
+    }
+
+    fn assert_selected(
+        installations: &[(&str, &str)],
+        environment: EnvironmentSelection,
+        expected: &str,
+    ) {
+        assert_eq!(selected(installations, environment), expected);
+    }
+
     #[test]
-    fn app_query_response_drives_the_complete_mint_request() {
-        for field in [
-            "$appId: String!",
-            "appsInstalledInContexts(",
-            "filters: {type: ONLY_APP_IDS, values: [$appId]}",
-            "installationsByContexts(contextIds: [$ctx])",
-            "envId: id",
-            "appEnvironmentVersion",
-            "extensionTypeKey",
-        ] {
-            assert!(APPS_QUERY.contains(field), "query missing {field}");
-        }
+    fn app_query_response_drives_mint_request() {
+        assert!(
+            [
+                "$appId: String!",
+                "appsInstalledInContexts(",
+                "filters: {type: ONLY_APP_IDS, values: [$appId]}",
+                "installationsByContexts(contextIds: [$ctx])",
+                "envId: id",
+                "appEnvironmentVersion",
+                "extensionTypeKey",
+            ]
+            .iter()
+            .all(|field| APPS_QUERY.contains(field))
+        );
         assert!(!APPS_QUERY.contains("$filters"));
-        let config = resolve(
-            serde_json::json!([installation(
-                "installation-1",
-                "environment-1",
-                "production",
-                "module-1"
-            )]),
+
+        let mut tester = tester();
+        tester.config = resolve(
+            &[("installation-1", "production")],
             EnvironmentSelection::Automatic,
         )
         .unwrap();
-        let mut tester = tester();
-        tester.config = config;
+        let context = serde_json::json!({ "fakebanana": true });
+        let request = tester
+            .mint_fct_request("installation-1-module", &context)
+            .unwrap();
 
+        assert_eq!(request.operation_name, GLOBAL_APP_OPERATION_NAME);
+        assert_eq!(request.query, DEFAULT_GLOBAL_APP_MUTATION);
         assert_eq!(
-            serde_json::to_value(
-                tester
-                    .mint_fct_request("module-1", &serde_json::json!({}))
-                    .unwrap(),
-            )
-            .unwrap(),
-            serde_json::json!({
-                "operationName": GLOBAL_APP_OPERATION_NAME,
-                "query": DEFAULT_GLOBAL_APP_MUTATION,
-                "variables": { "input": {
-                    "contextIds": [CONTEXT_ID],
-                    "extensionContexts": [{
-                        "appVersion": "1.0.0",
-                        "context": {},
-                        "extensionId": "ari:cloud:ecosystem::extension/app-1/environment-1/static/module-1",
-                        "extensionType": "jira:issuePanel",
-                        "installationId": "installation-1"
-                    }]
-                }}
-            })
-        );
-
-        assert_eq!(
-            tester
-                .mint_fct_request("module-1", &serde_json::json!({ "fakebanana": true }))
-                .unwrap()
-                .variables,
+            request.variables,
             serde_json::json!({
                 "input": {
                     "contextIds": [CONTEXT_ID],
                     "extensionContexts": [{
                         "appVersion": "1.0.0",
-                        "context": { "fakebanana": true },
-                        "extensionId": "ari:cloud:ecosystem::extension/app-1/environment-1/static/module-1",
+                        "context": context,
+                        "extensionId": "ari:cloud:ecosystem::extension/app-1/production-id/static/installation-1-module",
                         "extensionType": "jira:issuePanel",
                         "installationId": "installation-1"
                     }]
                 }
             })
         );
-    }
-
-    #[test]
-    fn environment_selection_is_only_used_for_multiple_installations() {
-        let config = resolve(
-            serde_json::json!([installation(
-                "installation-only",
-                "environment-development",
-                "development",
-                "module-only"
-            )]),
-            EnvironmentSelection::Key("staging".into()),
-        )
-        .unwrap();
-        assert_eq!(config.installation_id(), "installation-only");
-
-        let installations = || {
-            serde_json::json!([
-                installation(
-                    "installation-default",
-                    "environment-default",
-                    "default",
-                    "default-module"
-                ),
-                installation(
-                    "installation-production",
-                    "environment-production",
-                    "production",
-                    "production-module"
-                )
-            ])
-        };
-        for (selection, expected) in [
-            (EnvironmentSelection::Automatic, "installation-production"),
-            (
-                EnvironmentSelection::Key("default".into()),
-                "installation-default",
-            ),
-        ] {
-            let config = resolve(installations(), selection).unwrap();
-            assert_eq!(config.installation_id(), expected);
-        }
-
-        let config = resolve(
-            serde_json::json!([
-                installation(
-                    "installation-development",
-                    "environment-development",
-                    "development",
-                    "development-module"
-                ),
-                installation(
-                    "installation-staging",
-                    "environment-staging",
-                    "staging",
-                    "staging-module"
-                )
-            ]),
-            EnvironmentSelection::Automatic,
-        )
-        .unwrap();
-        assert_eq!(config.installation_id(), "installation-development");
-
-        let config = resolve(
-            serde_json::json!([
-                installation(
-                    "installation-production-first",
-                    "environment-production-first",
-                    "production",
-                    "production-module-first"
-                ),
-                installation(
-                    "installation-production-second",
-                    "environment-production-second",
-                    "production",
-                    "production-module-second"
-                )
-            ]),
-            EnvironmentSelection::Automatic,
-        )
-        .unwrap();
-        assert_eq!(config.installation_id(), "installation-production-first");
-    }
-
-    #[test]
-    fn app_query_selection_reports_missing_results() {
         assert!(matches!(
-            resolve(serde_json::json!([]), EnvironmentSelection::Automatic),
+            tester.mint_fct_request("installation-1-module", &serde_json::json!([])),
+            Err(MintError::InvalidFctContext)
+        ));
+    }
+
+    #[test]
+    fn selects_installations_and_reports_errors() {
+        use EnvironmentSelection::{Automatic, Key};
+
+        assert_selected(&[("only", "development")], Key("missing".into()), "only");
+        let preferred = [("default", "default"), ("production", "production")];
+        assert_selected(&preferred, Automatic, "production");
+        assert_selected(&preferred, Key("default".into()), "default");
+        assert_selected(
+            &[("development", "development"), ("staging", "staging")],
+            Automatic,
+            "development",
+        );
+        assert_selected(
+            &[("first", "production"), ("second", "production")],
+            Automatic,
+            "first",
+        );
+
+        assert!(matches!(
+            resolve(&[], Automatic),
             Err(MintError::NoInstallations { .. })
         ));
         assert!(matches!(
             resolve(
-                serde_json::json!([
-                    installation(
-                        "installation-1",
-                        "environment-production",
-                        "production",
-                        "module-1"
-                    ),
-                    installation(
-                        "installation-2",
-                        "environment-default",
-                        "default",
-                        "module-2"
-                    )
-                ]),
-                EnvironmentSelection::Key("staging".into())
+                &[("production", "production"), ("default", "default")],
+                Key("staging".into())
             ),
             Err(MintError::EnvironmentNotFound { .. })
         ));
@@ -841,13 +738,13 @@ mod tests {
     #[test]
     fn cached_fct_returns_valid_tokens_and_reports_other_states() {
         let tester = tester();
-        let valid = jwt_with_exp(unix_time() + 60);
+        let valid = jwt(now() + 60);
         tester.cached_fct_jwt.borrow_mut().clone_from(&valid);
         assert_eq!(tester.cached_fct_jwt().unwrap(), valid);
 
         for (jwt, expected) in [
             (String::new(), JwtValidity::Invalid),
-            (jwt_with_exp(unix_time() - 60), JwtValidity::Expired),
+            (jwt(now() - 60), JwtValidity::Expired),
             ("not-a-jwt".into(), JwtValidity::Invalid),
         ] {
             tester.cached_fct_jwt.borrow_mut().clone_from(&jwt);
@@ -856,76 +753,44 @@ mod tests {
     }
 
     #[test]
-    fn fit_request_contains_only_the_fct_and_selected_remote() {
-        let tester = tester();
+    fn builds_fit_request() {
+        let request = tester()
+            .mint_fit_request("module", "fct", "remote")
+            .unwrap();
 
+        assert_eq!(request.operation_name, FIT_OPERATION_NAME);
+        assert_eq!(request.query, FIT_MUTATION);
         assert_eq!(
-            serde_json::to_value(
-                tester
-                    .mint_fit_request("first-module", "provided-fct", "primary-remote")
-                    .unwrap()
-            )
-            .unwrap(),
+            request.variables,
             serde_json::json!({
-                "operationName": FIT_OPERATION_NAME,
-                "query": FIT_MUTATION,
-                "variables": { "input": {
-                    "forgeContextToken": "provided-fct",
-                    "remoteKey": "primary-remote"
-                }}
+                "input": {
+                    "forgeContextToken": "fct",
+                    "remoteKey": "remote"
+                }
             })
         );
     }
 
     #[test]
-    fn fct_context_is_applied_only_to_the_fct_request() {
-        let tester = tester();
-        let context = serde_json::json!({ "issueKey": "TEST-1", "nested": { "admin": true } });
-        let request = tester.mint_fct_request("first-module", &context).unwrap();
-
-        assert_eq!(
-            request.variables["input"]["extensionContexts"][0]["context"],
-            context
-        );
-        assert!(matches!(
-            tester.mint_fct_request("first-module", &serde_json::json!([])),
-            Err(MintError::InvalidFctContext)
-        ));
-    }
-
-    #[test]
-    fn fit_request_rejects_invalid_inputs() {
+    fn rejects_invalid_fit_inputs() {
         let tester = tester();
 
         assert!(matches!(
-            tester.mint_fit_request("missing-module", "fct", "primary-remote"),
-            Err(MintError::ModuleKeyNotFound { module_key, .. })
-                if module_key == "missing-module"
+            tester.mint_fit_request("missing", "fct", "remote"),
+            Err(MintError::ModuleKeyNotFound { .. })
         ));
         assert!(matches!(
-            tester.mint_fit_request("first-module", "fct", "missing"),
-            Err(MintError::RemoteKeyNotFound { remote_key, available })
-                if remote_key == "missing"
-                    && available == ["primary-remote", "secondary-remote"]
+            tester.mint_fit_request("module", "fct", "missing"),
+            Err(MintError::RemoteKeyNotFound { .. })
         ));
         assert!(matches!(
-            tester.mint_fit_request("first-module", "  ", "primary-remote"),
+            tester.mint_fit_request("module", "  ", "remote"),
             Err(MintError::EmptySuppliedFct)
         ));
         assert!(matches!(
             tester.mint_fit(
-                "missing-module",
-                "primary-remote",
-                None,
-                Some("provided-fct")
-            ),
-            Err(MintError::ModuleKeyNotFound { module_key, .. })
-                if module_key == "missing-module"
-        ));
-        assert!(matches!(
-            tester.mint_fit(
-                "first-module",
-                "primary-remote",
+                "module",
+                "remote",
                 Some(&serde_json::json!([])),
                 Some("provided-fct")
             ),

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -381,41 +381,9 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         })
     }
 
-    /// Mints a FIT using a supplied FCT, a valid cached FCT, or a newly minted FCT.
-    pub fn mint_fit(
-        &self,
-        module_key: Option<&str>,
-        remote_key: &str,
-        context: Option<&serde_json::Value>,
-        supplied_fct: Option<&str>,
-    ) -> Result<String, MintError> {
-        let fct = if let Some(context) = context {
-            let module_key = module_key.ok_or(MintError::MissingModuleKey)?;
-            let fct = self.mint_fct(module_key, context)?;
-            info!(context = %context, "minted new Forge Context Token for FIT minting");
-            fct
-        } else {
-            match supplied_fct {
-                Some(fct) => {
-                    info!("using supplied Forge Context Token for FIT minting");
-                    fct.to_string()
-                }
-                None => match self.cached_fct_jwt() {
-                    Ok(fct) => {
-                        info!("using cached Forge Context Token for FIT minting");
-                        fct
-                    }
-                    Err(validity) => {
-                        let module_key = module_key.ok_or(MintError::MissingModuleKey)?;
-                        let fct = self.mint_fct(module_key, &serde_json::json!({}))?;
-                        info!(?validity, "minted new Forge Context Token for FIT minting");
-                        fct
-                    }
-                },
-            }
-        };
-
-        let request = self.mint_fit_request(&fct, remote_key)?;
+    /// Mints a FIT for a Forge remote using the supplied FCT.
+    pub fn mint_fit(&self, remote_key: &str, fct: &str) -> Result<String, MintError> {
+        let request = self.mint_fit_request(fct, remote_key)?;
         let mut variables = request.variables.clone();
         variables["input"]["forgeContextToken"] = REDACTED_FCT.into();
         let variables = format!("{variables:#}");
@@ -782,21 +750,12 @@ mod tests {
             Err(MintError::EmptySuppliedFct)
         ));
         assert!(matches!(
-            tester.mint_fit(
-                Some("module"),
-                "remote",
-                Some(&serde_json::json!([])),
-                Some("provided-fct")
-            ),
-            Err(MintError::InvalidFctContext)
-        ));
-        assert!(matches!(
-            tester.mint_fit(None, "remote", Some(&serde_json::json!({})), None),
-            Err(MintError::MissingModuleKey)
-        ));
-        assert!(matches!(
-            tester.mint_fit(None, "missing", None, Some("provided-fct")),
+            tester.mint_fit("missing", "provided-fct"),
             Err(MintError::RemoteKeyNotFound { .. })
+        ));
+        assert!(matches!(
+            tester.mint_fit("remote", "  "),
+            Err(MintError::EmptySuppliedFct)
         ));
     }
 }

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -361,11 +361,9 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
     /// Constructs the exact GraphQL request used to mint a FIT.
     pub fn mint_fit_request(
         &self,
-        module_key: &str,
         fct: &str,
         remote_key: &str,
     ) -> Result<GraphqlRequest<serde_json::Value>, MintError> {
-        self.config.extension_for_module_key(module_key)?;
         validate_remote_key(self.manifest, remote_key)?;
         if fct.trim().is_empty() {
             return Err(MintError::EmptySuppliedFct);
@@ -386,12 +384,13 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
     /// Mints a FIT using a supplied FCT, a valid cached FCT, or a newly minted FCT.
     pub fn mint_fit(
         &self,
-        module_key: &str,
+        module_key: Option<&str>,
         remote_key: &str,
         context: Option<&serde_json::Value>,
         supplied_fct: Option<&str>,
     ) -> Result<String, MintError> {
         let fct = if let Some(context) = context {
+            let module_key = module_key.ok_or(MintError::MissingModuleKey)?;
             let fct = self.mint_fct(module_key, context)?;
             info!(context = %context, "minted new Forge Context Token for FIT minting");
             fct
@@ -407,6 +406,7 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
                         fct
                     }
                     Err(validity) => {
+                        let module_key = module_key.ok_or(MintError::MissingModuleKey)?;
                         let fct = self.mint_fct(module_key, &serde_json::json!({}))?;
                         info!(?validity, "minted new Forge Context Token for FIT minting");
                         fct
@@ -415,7 +415,7 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             }
         };
 
-        let request = self.mint_fit_request(module_key, &fct, remote_key)?;
+        let request = self.mint_fit_request(&fct, remote_key)?;
         let mut variables = request.variables.clone();
         variables["input"]["forgeContextToken"] = REDACTED_FCT.into();
         let variables = format!("{variables:#}");
@@ -754,9 +754,7 @@ mod tests {
 
     #[test]
     fn builds_fit_request() {
-        let request = tester()
-            .mint_fit_request("module", "fct", "remote")
-            .unwrap();
+        let request = tester().mint_fit_request("fct", "remote").unwrap();
 
         assert_eq!(request.operation_name, FIT_OPERATION_NAME);
         assert_eq!(request.query, FIT_MUTATION);
@@ -776,25 +774,29 @@ mod tests {
         let tester = tester();
 
         assert!(matches!(
-            tester.mint_fit_request("missing", "fct", "remote"),
-            Err(MintError::ModuleKeyNotFound { .. })
-        ));
-        assert!(matches!(
-            tester.mint_fit_request("module", "fct", "missing"),
+            tester.mint_fit_request("fct", "missing"),
             Err(MintError::RemoteKeyNotFound { .. })
         ));
         assert!(matches!(
-            tester.mint_fit_request("module", "  ", "remote"),
+            tester.mint_fit_request("  ", "remote"),
             Err(MintError::EmptySuppliedFct)
         ));
         assert!(matches!(
             tester.mint_fit(
-                "module",
+                Some("module"),
                 "remote",
                 Some(&serde_json::json!([])),
                 Some("provided-fct")
             ),
             Err(MintError::InvalidFctContext)
+        ));
+        assert!(matches!(
+            tester.mint_fit(None, "remote", Some(&serde_json::json!({})), None),
+            Err(MintError::MissingModuleKey)
+        ));
+        assert!(matches!(
+            tester.mint_fit(None, "missing", None, Some("provided-fct")),
+            Err(MintError::RemoteKeyNotFound { .. })
         ));
     }
 }

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -72,6 +72,15 @@ const DEFAULT_GLOBAL_APP_MUTATION: &str = r#"mutation SignForgeContextToken($inp
   }
 }"#;
 const GLOBAL_APP_OPERATION_NAME: &str = "SignForgeContextToken";
+const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvocationTokenForUIInput!) {
+  signInvocationTokenForUI(input: $input) {
+    forgeInvocationToken {
+      jwt
+      expiresAt
+    }
+  }
+}"#;
+const FIT_OPERATION_NAME: &str = "SignInvocationTokenForUI";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum EnvironmentSelection {
@@ -165,7 +174,39 @@ struct FctToken {
     jwt: String,
 }
 
-/// Reusable client for minting Forge Context Tokens.
+#[derive(Debug, Deserialize)]
+struct FitData {
+    #[serde(rename = "signInvocationTokenForUI")]
+    result: Option<FitResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FitResult {
+    #[serde(rename = "forgeInvocationToken")]
+    token: Option<ForgeInvocationToken>,
+}
+
+/// A minted Forge Invocation Token and its server-provided expiration.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ForgeInvocationToken {
+    jwt: String,
+    #[serde(rename = "expiresAt")]
+    expires_at: String,
+}
+
+impl ForgeInvocationToken {
+    /// Returns the signed Forge Invocation Token JWT.
+    pub fn jwt(&self) -> &str {
+        &self.jwt
+    }
+
+    /// Returns the server-provided expiration value.
+    pub fn expires_at(&self) -> &str {
+        &self.expires_at
+    }
+}
+
+/// Reusable client for minting Forge Context and Invocation Tokens.
 ///
 /// Reuses authentication, one [`Agent`], and a deployment snapshot.
 pub struct ForgePenTester<'manifest, 'source> {
@@ -266,6 +307,9 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         module_key: &str,
         ctx: &serde_json::Value,
     ) -> Result<GraphqlRequest<serde_json::Value>, MintError> {
+        if !ctx.is_object() {
+            return Err(MintError::InvalidFctContext);
+        }
         let extension = self.config.extension_for_module_key(module_key)?;
         info!(
             module_key = ?module_key,
@@ -327,6 +371,93 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         self.cached_fct_jwt.borrow_mut().clone_from(&jwt);
         debug!("successfully minted Forge Context Token");
         Ok(jwt)
+    }
+
+    /// Constructs the exact GraphQL request used to mint a FIT.
+    pub fn mint_fit_request(
+        &self,
+        module_key: &str,
+        fct: &str,
+        remote_key: &str,
+    ) -> Result<GraphqlRequest<serde_json::Value>, MintError> {
+        self.config.extension_for_module_key(module_key)?;
+        validate_remote_key(self.manifest, remote_key)?;
+        if fct.trim().is_empty() {
+            return Err(MintError::EmptySuppliedFct);
+        }
+
+        Ok(GraphqlRequest {
+            operation_name: FIT_OPERATION_NAME.to_string(),
+            query: FIT_MUTATION.to_string(),
+            variables: serde_json::json!({
+                "input": {
+                    "forgeContextToken": fct,
+                    "remoteKey": remote_key
+                }
+            }),
+        })
+    }
+
+    /// Mints a FIT using a supplied FCT, a valid cached FCT, or a newly minted FCT.
+    pub fn mint_fit(
+        &self,
+        module_key: &str,
+        remote_key: &str,
+        context: Option<&serde_json::Value>,
+        supplied_fct: Option<&str>,
+    ) -> Result<ForgeInvocationToken, MintError> {
+        let fct = if let Some(context) = context {
+            let fct = self.mint_fct(module_key, context)?;
+            info!(context = %context, "minted new Forge Context Token for FIT minting");
+            fct
+        } else {
+            match supplied_fct {
+                Some(fct) => {
+                    info!("using supplied Forge Context Token for FIT minting");
+                    fct.to_string()
+                }
+                None => match self.cached_fct_jwt() {
+                    Ok(fct) => {
+                        info!("using cached Forge Context Token for FIT minting");
+                        fct
+                    }
+                    Err(validity) => {
+                        let fct = self.mint_fct(module_key, &serde_json::json!({}))?;
+                        info!(?validity, "minted new Forge Context Token for FIT minting");
+                        fct
+                    }
+                },
+            }
+        };
+
+        let request = self.mint_fit_request(module_key, &fct, remote_key)?;
+        let data: FitData = self.post_graphql_mutation(&request)?;
+        let token = data
+            .result
+            .and_then(|result| result.token)
+            .ok_or(MintError::MissingFitToken)?;
+        debug!("successfully minted Forge Invocation Token");
+        Ok(token)
+    }
+}
+
+fn validate_remote_key(manifest: &ForgeManifest<'_>, remote_key: &str) -> Result<(), MintError> {
+    let available = manifest
+        .remotes
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter(|remote| !remote.key.is_empty())
+        .map(|remote| remote.key.clone())
+        .collect::<Vec<_>>();
+
+    if available.iter().any(|available| available == remote_key) {
+        Ok(())
+    } else {
+        Err(MintError::RemoteKeyNotFound {
+            remote_key: remote_key.to_string(),
+            available,
+        })
     }
 }
 
@@ -428,48 +559,9 @@ fn resolve_app_config(
 mod tests {
     use super::*;
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-    use std::io::Read;
-    use ureq::{
-        Body, SendBody,
-        http::{Request, Response},
-        middleware::{Middleware, MiddlewareNext},
-    };
 
     const APP_ID: &str = "ari:cloud:ecosystem::app/app-1";
     const CONTEXT_ID: &str = "ari:cloud:jira::site/cloud-1";
-
-    struct GraphqlMock {
-        response_body: String,
-        expected_request: serde_json::Value,
-    }
-
-    impl Middleware for GraphqlMock {
-        fn handle(
-            &self,
-            request: Request<SendBody<'_>>,
-            _next: MiddlewareNext<'_>,
-        ) -> Result<Response<Body>, ureq::Error> {
-            assert_eq!(
-                request.uri(),
-                "https://www.atlassian.net/gateway/api/graphql"
-            );
-            let mut request_body = String::new();
-            request
-                .into_body()
-                .into_reader()
-                .read_to_string(&mut request_body)
-                .unwrap();
-            assert_eq!(
-                serde_json::from_str::<serde_json::Value>(&request_body).unwrap(),
-                self.expected_request
-            );
-            Ok(Response::builder()
-                .status(200)
-                .header("Content-Type", "application/json")
-                .body(Body::builder().data(self.response_body.clone()))
-                .unwrap())
-        }
-    }
 
     fn unix_time() -> i64 {
         std::time::SystemTime::now()
@@ -496,8 +588,20 @@ mod tests {
         }
     }
 
-    fn tester_with_agent(agent: Agent) -> ForgePenTester<'static, 'static> {
-        let manifest = Box::leak(Box::new(ForgeManifest::default()));
+    fn tester() -> ForgePenTester<'static, 'static> {
+        let manifest = Box::leak(Box::new(ForgeManifest {
+            remotes: Some(vec![
+                forge_loader::manifest::Remotes {
+                    key: "primary-remote".into(),
+                    auth: Default::default(),
+                },
+                forge_loader::manifest::Remotes {
+                    key: "secondary-remote".into(),
+                    auth: Default::default(),
+                },
+            ]),
+            ..ForgeManifest::default()
+        }));
         ForgePenTester {
             config: AppConfig {
                 context_id: CONTEXT_ID.into(),
@@ -508,40 +612,10 @@ mod tests {
                 ],
                 installation_id: "installation-1".into(),
             },
-            agent,
+            agent: Agent::new_with_defaults(),
             manifest,
             cached_fct_jwt: RefCell::new(String::new()),
         }
-    }
-
-    fn tester_with_graphql_response(
-        request: &impl serde::Serialize,
-        response: serde_json::Value,
-    ) -> ForgePenTester<'static, 'static> {
-        let agent = ureq::Agent::config_builder()
-            .http_status_as_error(false)
-            .middleware(GraphqlMock {
-                response_body: response.to_string(),
-                expected_request: serde_json::to_value(request).unwrap(),
-            })
-            .build()
-            .into();
-        tester_with_agent(agent)
-    }
-
-    fn tester_with_mint_result(
-        result: serde_json::Value,
-        module_key: &str,
-    ) -> ForgePenTester<'static, 'static> {
-        let request = tester_with_agent(ureq::Agent::new_with_defaults())
-            .mint_fct_request(module_key, &serde_json::json!({}))
-            .unwrap();
-        tester_with_graphql_response(
-            &request,
-            serde_json::json!({
-                "data": { "globalApp_signForgeContextTokens": result }
-            }),
-        )
     }
 
     fn installation(
@@ -608,7 +682,7 @@ mod tests {
             EnvironmentSelection::Automatic,
         )
         .unwrap();
-        let mut tester = tester_with_agent(ureq::Agent::new_with_defaults());
+        let mut tester = tester();
         tester.config = config;
 
         assert_eq!(
@@ -652,25 +726,6 @@ mod tests {
                 }
             })
         );
-    }
-
-    #[test]
-    fn post_graphql_mutation_returns_generic_data() {
-        #[derive(Deserialize)]
-        struct MutationData {
-            value: u8,
-        }
-
-        let request = GraphqlRequest {
-            operation_name: "MutationUnderTest".into(),
-            query: "mutation MutationUnderTest { value }".into(),
-            variables: serde_json::json!({}),
-        };
-        let tester =
-            tester_with_graphql_response(&request, serde_json::json!({ "data": { "value": 7 } }));
-
-        let data: MutationData = tester.post_graphql_mutation(&request).unwrap();
-        assert_eq!(data.value, 7);
     }
 
     #[test]
@@ -784,49 +839,8 @@ mod tests {
     }
 
     #[test]
-    fn successful_mint_uses_the_shared_request_and_replaces_the_cache() {
-        let jwt = jwt_with_exp(unix_time() + 60);
-        let tester = tester_with_mint_result(
-            serde_json::json!({
-                "success": true,
-                "errors": [],
-                "tokens": [{ "jwt": jwt }]
-            }),
-            "second-module",
-        );
-
-        let minted = tester
-            .mint_fct("second-module", &serde_json::json!({}))
-            .unwrap();
-        assert_eq!(tester.cached_fct_jwt().unwrap(), minted);
-    }
-
-    #[test]
-    fn mutation_error_objects_are_preserved() {
-        let tester = tester_with_mint_result(
-            serde_json::json!({
-                "success": false,
-                "errors": [{ "message": "denied" }, { "message": null }],
-                "tokens": []
-            }),
-            "first-module",
-        );
-
-        let MintError::MintRejected { success, errors } = tester
-            .mint_fct("first-module", &serde_json::json!({}))
-            .unwrap_err()
-        else {
-            panic!("unexpected error variant")
-        };
-        assert!(!success);
-        assert_eq!(errors.len(), 2);
-        assert_eq!(errors[0].message.as_deref(), Some("denied"));
-        assert_eq!(errors[1].message, None);
-    }
-
-    #[test]
     fn cached_fct_returns_valid_tokens_and_reports_other_states() {
-        let tester = tester_with_agent(ureq::Agent::new_with_defaults());
+        let tester = tester();
         let valid = jwt_with_exp(unix_time() + 60);
         tester.cached_fct_jwt.borrow_mut().clone_from(&valid);
         assert_eq!(tester.cached_fct_jwt().unwrap(), valid);
@@ -839,5 +853,83 @@ mod tests {
             tester.cached_fct_jwt.borrow_mut().clone_from(&jwt);
             assert_eq!(tester.cached_fct_jwt(), Err(expected));
         }
+    }
+
+    #[test]
+    fn fit_request_contains_only_the_fct_and_selected_remote() {
+        let tester = tester();
+
+        assert_eq!(
+            serde_json::to_value(
+                tester
+                    .mint_fit_request("first-module", "provided-fct", "primary-remote")
+                    .unwrap()
+            )
+            .unwrap(),
+            serde_json::json!({
+                "operationName": FIT_OPERATION_NAME,
+                "query": FIT_MUTATION,
+                "variables": { "input": {
+                    "forgeContextToken": "provided-fct",
+                    "remoteKey": "primary-remote"
+                }}
+            })
+        );
+    }
+
+    #[test]
+    fn fct_context_is_applied_only_to_the_fct_request() {
+        let tester = tester();
+        let context = serde_json::json!({ "issueKey": "TEST-1", "nested": { "admin": true } });
+        let request = tester.mint_fct_request("first-module", &context).unwrap();
+
+        assert_eq!(
+            request.variables["input"]["extensionContexts"][0]["context"],
+            context
+        );
+        assert!(matches!(
+            tester.mint_fct_request("first-module", &serde_json::json!([])),
+            Err(MintError::InvalidFctContext)
+        ));
+    }
+
+    #[test]
+    fn fit_request_rejects_invalid_inputs() {
+        let tester = tester();
+
+        assert!(matches!(
+            tester.mint_fit_request("missing-module", "fct", "primary-remote"),
+            Err(MintError::ModuleKeyNotFound { module_key, .. })
+                if module_key == "missing-module"
+        ));
+        assert!(matches!(
+            tester.mint_fit_request("first-module", "fct", "missing"),
+            Err(MintError::RemoteKeyNotFound { remote_key, available })
+                if remote_key == "missing"
+                    && available == ["primary-remote", "secondary-remote"]
+        ));
+        assert!(matches!(
+            tester.mint_fit_request("first-module", "  ", "primary-remote"),
+            Err(MintError::EmptySuppliedFct)
+        ));
+        assert!(matches!(
+            tester.mint_fit(
+                "missing-module",
+                "primary-remote",
+                None,
+                Some("provided-fct")
+            ),
+            Err(MintError::ModuleKeyNotFound { module_key, .. })
+                if module_key == "missing-module"
+        ));
+        assert!(matches!(
+            tester.mint_fit(
+                "first-module",
+                "primary-remote",
+                Some(&serde_json::json!([])),
+                Some("provided-fct")
+            ),
+            Err(MintError::InvalidFctContext)
+        ));
     }
 }

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -364,7 +364,6 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         fct: &str,
         remote_key: &str,
     ) -> Result<GraphqlRequest<serde_json::Value>, MintError> {
-        validate_remote_key(self.manifest, remote_key)?;
         if fct.trim().is_empty() {
             return Err(MintError::EmptySuppliedFct);
         }
@@ -392,33 +391,19 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             variables = %variables,
             "FIT GraphQL variables"
         );
-        let data: FitData = self.post_graphql_mutation(&request)?;
-        let token = data
-            .result
-            .and_then(|result| result.token)
-            .ok_or(MintError::MissingFitToken)?;
+        let token = (|| {
+            let data: FitData = self.post_graphql_mutation(&request)?;
+            data.result
+                .and_then(|result| result.token)
+                .map(|token| token.jwt)
+                .ok_or(MintError::MissingFitToken)
+        })()
+        .map_err(|source| MintError::FitMintFailed {
+            source: Box::new(source),
+            available: self.config.remote_keys(),
+        })?;
         debug!("successfully minted Forge Invocation Token");
-        Ok(token.jwt)
-    }
-}
-
-fn validate_remote_key(manifest: &ForgeManifest<'_>, remote_key: &str) -> Result<(), MintError> {
-    let available = manifest
-        .remotes
-        .as_deref()
-        .unwrap_or_default()
-        .iter()
-        .filter(|remote| !remote.key.is_empty())
-        .map(|remote| remote.key.clone())
-        .collect::<Vec<_>>();
-
-    if available.iter().any(|available| available == remote_key) {
-        Ok(())
-    } else {
-        Err(MintError::RemoteKeyNotFound {
-            remote_key: remote_key.to_string(),
-            available,
-        })
+        Ok(token)
     }
 }
 
@@ -520,6 +505,11 @@ fn resolve_app_config(
 mod tests {
     use super::*;
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use ureq::{
+        Body, SendBody,
+        http::{Request, Response},
+        middleware::MiddlewareNext,
+    };
 
     const APP_ID: &str = "ari:cloud:ecosystem::app/app-1";
     const CONTEXT_ID: &str = "ari:cloud:jira::site/cloud-1";
@@ -538,13 +528,7 @@ mod tests {
     }
 
     fn tester() -> ForgePenTester<'static, 'static> {
-        let manifest = Box::leak(Box::new(ForgeManifest {
-            remotes: Some(vec![forge_loader::manifest::Remotes {
-                key: "remote".into(),
-                ..Default::default()
-            }]),
-            ..ForgeManifest::default()
-        }));
+        let manifest = Box::leak(Box::new(ForgeManifest::default()));
         ForgePenTester {
             config: AppConfig {
                 context_id: CONTEXT_ID.into(),
@@ -561,6 +545,32 @@ mod tests {
             manifest,
             cached_fct_jwt: RefCell::new(String::new()),
         }
+    }
+
+    fn deployed_extension(module_key: &str, extension_type: &str) -> ExtensionConfig {
+        ExtensionConfig {
+            module_key: module_key.into(),
+            deployment_id: format!("{module_key}-deployment"),
+            extension_id: format!("{module_key}-extension"),
+            extension_type: extension_type.into(),
+        }
+    }
+
+    fn response_agent(status: u16, body: impl Into<String>) -> Agent {
+        let body = body.into();
+        Agent::config_builder()
+            .http_status_as_error(false)
+            .middleware(
+                move |_request: Request<SendBody<'_>>, _next: MiddlewareNext<'_>| {
+                    Ok(Response::builder()
+                        .status(status)
+                        .header("Content-Type", "application/json")
+                        .body(Body::builder().data(body.clone()))
+                        .unwrap())
+                },
+            )
+            .build()
+            .into()
     }
 
     fn installation(id: &str, environment: &str) -> serde_json::Value {
@@ -722,7 +732,9 @@ mod tests {
 
     #[test]
     fn builds_fit_request() {
-        let request = tester().mint_fit_request("fct", "remote").unwrap();
+        let request = tester()
+            .mint_fit_request("fct", "not-declared-in-manifest")
+            .unwrap();
 
         assert_eq!(request.operation_name, FIT_OPERATION_NAME);
         assert_eq!(request.query, FIT_MUTATION);
@@ -731,31 +743,55 @@ mod tests {
             serde_json::json!({
                 "input": {
                     "forgeContextToken": "fct",
-                    "remoteKey": "remote"
+                    "remoteKey": "not-declared-in-manifest"
                 }
             })
         );
     }
 
     #[test]
-    fn rejects_invalid_fit_inputs() {
+    fn rejects_an_empty_fct_without_wrapping_it_as_a_fit_failure() {
         let tester = tester();
 
-        assert!(matches!(
-            tester.mint_fit_request("fct", "missing"),
-            Err(MintError::RemoteKeyNotFound { .. })
-        ));
         assert!(matches!(
             tester.mint_fit_request("  ", "remote"),
             Err(MintError::EmptySuppliedFct)
         ));
         assert!(matches!(
-            tester.mint_fit("missing", "provided-fct"),
-            Err(MintError::RemoteKeyNotFound { .. })
-        ));
-        assert!(matches!(
             tester.mint_fit("remote", "  "),
             Err(MintError::EmptySuppliedFct)
         ));
+    }
+
+    #[test]
+    fn failed_fit_mint_preserves_the_error_and_reports_deployed_remotes() {
+        let mut tester = tester();
+        tester.agent = response_agent(200, r#"{"errors":[{"message":"unknown remote"}]}"#);
+        tester.config.extensions.extend([
+            deployed_extension("remote-b", "core:remote"),
+            deployed_extension("panel", "jira:issuePanel"),
+            deployed_extension("remote-a", "core:remote"),
+        ]);
+
+        let error = tester
+            .mint_fit("not-declared-in-manifest", "provided-fct")
+            .unwrap_err();
+        let display = error.to_string();
+        let MintError::FitMintFailed { source, available } = error else {
+            panic!("unexpected error variant")
+        };
+
+        assert!(matches!(
+            source.as_ref(),
+            MintError::GraphqlRejected { errors, .. }
+                if errors.first().and_then(|error| error.message.as_deref())
+                    == Some("unknown remote")
+        ));
+        assert_eq!(
+            available,
+            vec!["remote-a".to_string(), "remote-b".to_string()]
+        );
+        assert!(display.contains("unknown remote"));
+        assert!(display.contains("possible remotes: [\"remote-a\", \"remote-b\"]"));
     }
 }

--- a/crates/forge_pen_test/src/lib.rs
+++ b/crates/forge_pen_test/src/lib.rs
@@ -6,6 +6,6 @@ mod fsrt_remote_config;
 mod mint_common;
 
 pub use app_config::{AppConfig, ExtensionConfig};
-pub use forge_pentester::{ForgeInvocationToken, ForgePenTester};
+pub use forge_pentester::ForgePenTester;
 pub use fsrt_remote_config::{AuthConfig, FsrtRemoteConfig};
 pub use mint_common::{GraphqlErrorObject, GraphqlRequest, JwtValidity, MintError};

--- a/crates/forge_pen_test/src/lib.rs
+++ b/crates/forge_pen_test/src/lib.rs
@@ -6,6 +6,6 @@ mod fsrt_remote_config;
 mod mint_common;
 
 pub use app_config::{AppConfig, ExtensionConfig};
-pub use forge_pentester::ForgePenTester;
+pub use forge_pentester::{ForgeInvocationToken, ForgePenTester};
 pub use fsrt_remote_config::{AuthConfig, FsrtRemoteConfig};
 pub use mint_common::{GraphqlErrorObject, GraphqlRequest, JwtValidity, MintError};

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -38,9 +38,6 @@ pub struct GraphqlErrorObject {
 /// Errors produced while constructing or minting Forge tokens.
 #[derive(Debug, thiserror::Error)]
 pub enum MintError {
-    #[error("a module key is required when an FCT must be minted")]
-    MissingModuleKey,
-
     #[error("could not read {kind} file '{path}'")]
     FileRead {
         kind: &'static str,

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -38,6 +38,9 @@ pub struct GraphqlErrorObject {
 /// Errors produced while constructing or minting Forge tokens.
 #[derive(Debug, thiserror::Error)]
 pub enum MintError {
+    #[error("a module key is required when an FCT must be minted")]
+    MissingModuleKey,
+
     #[error("could not read {kind} file '{path}'")]
     FileRead {
         kind: &'static str,

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -149,9 +149,10 @@ pub enum MintError {
         available: Vec<String>,
     },
 
-    #[error("remote '{remote_key}' not found; available: {available:?}")]
-    RemoteKeyNotFound {
-        remote_key: String,
+    #[error("FIT minting failed: {source}; possible remotes: {available:?}")]
+    FitMintFailed {
+        #[source]
+        source: Box<MintError>,
         available: Vec<String>,
     },
 

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -35,7 +35,7 @@ pub struct GraphqlErrorObject {
     pub message: Option<String>,
 }
 
-/// Errors produced while constructing or minting an FCT.
+/// Errors produced while constructing or minting Forge tokens.
 #[derive(Debug, thiserror::Error)]
 pub enum MintError {
     #[error("could not read {kind} file '{path}'")]
@@ -149,6 +149,18 @@ pub enum MintError {
         available: Vec<String>,
     },
 
+    #[error("remote '{remote_key}' not found; available: {available:?}")]
+    RemoteKeyNotFound {
+        remote_key: String,
+        available: Vec<String>,
+    },
+
+    #[error("FCT context must be a JSON object")]
+    InvalidFctContext,
+
+    #[error("supplied FCT must not be empty")]
+    EmptySuppliedFct,
+
     #[error("FCT mutation was rejected (success: {success}): {errors:?}")]
     MintRejected {
         success: bool,
@@ -157,6 +169,9 @@ pub enum MintError {
 
     #[error("FCT response has no token")]
     MissingFctToken,
+
+    #[error("FIT response has no token")]
+    MissingFitToken,
 }
 
 /// Structural and expiry status of a JWT.

--- a/crates/fsrt/src/commands/mint_fct.rs
+++ b/crates/fsrt/src/commands/mint_fct.rs
@@ -5,6 +5,8 @@ use tracing::info;
 
 use crate::{Result, forge_project::find_manifest_path};
 
+use super::parse_ctx;
+
 /// `mint-fct` arguments.
 #[derive(Args, Debug)]
 pub(crate) struct MintFctArgs {
@@ -27,17 +29,6 @@ pub(crate) struct MintFctArgs {
     /// Query metadata and print the GraphQL request without minting.
     #[arg(long, default_value_t = false)]
     dry_run: bool,
-}
-
-fn parse_ctx(value: &str) -> std::result::Result<serde_json::Value, String> {
-    let ctx: serde_json::Value =
-        serde_json::from_str(value).map_err(|error| format!("invalid JSON: {error}"))?;
-
-    if !ctx.is_object() {
-        return Err("ctx must be a JSON object".to_string());
-    }
-
-    Ok(ctx)
 }
 
 impl MintFctArgs {

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -11,10 +11,14 @@ const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
 /// `mint-fit` arguments.
 #[derive(Args, Debug)]
-#[command(allow_missing_positional = true)]
 pub(crate) struct MintFitArgs {
     /// Deployed module key used when an FCT must be minted.
-    #[arg(name = "MODULE_KEY", required_unless_present = "fct")]
+    #[arg(
+        long = "module",
+        value_name = "MODULE_KEY",
+        required_unless_present = "fct",
+        conflicts_with = "fct"
+    )]
     module_key: Option<String>,
 
     /// Forge remote key to sign the invocation for.
@@ -22,11 +26,16 @@ pub(crate) struct MintFitArgs {
     remote_key: String,
 
     /// Force a new FCT with this inline JSON object as its context.
-    #[arg(long = "ctx", value_parser = parse_ctx, requires = "MODULE_KEY")]
+    #[arg(
+        long = "ctx",
+        value_parser = parse_ctx,
+        requires = "module_key",
+        conflicts_with = "fct"
+    )]
     ctx: Option<Value>,
 
     /// Existing FCT to pass in.
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["module_key", "ctx"])]
     fct: Option<String>,
 
     /// Forge app directory.
@@ -61,17 +70,13 @@ pub(super) fn run(args: &MintFitArgs) -> Result<()> {
         return Ok(());
     }
 
-    let fct = if args.ctx.is_some() || args.fct.is_none() {
-        let module_key = args
-            .module_key
-            .as_deref()
-            .expect("clap requires MODULE_KEY when an FCT must be minted");
+    let fct = if let Some(module_key) = args.module_key.as_deref() {
         let ctx = args.ctx.clone().unwrap_or_else(|| serde_json::json!({}));
         tester.mint_fct(module_key, &ctx)?
     } else {
         args.fct
             .clone()
-            .expect("an FCT is present when minting is not required")
+            .expect("clap requires either MODULE_KEY or an existing FCT")
     };
     let token = tester.mint_fit(&args.remote_key, &fct)?;
     println!("{token}");
@@ -91,53 +96,66 @@ mod tests {
     }
 
     #[test]
-    fn parses_required_keys_and_optional_fit_inputs() {
-        let args = TestArgs::try_parse_from([
-            "fsrt",
-            "module-key",
-            "remote-key",
-            "--ctx",
-            r#"{"issueKey":"TEST-1"}"#,
-            "--fct",
-            "provided-fct",
-            "--dry-run",
-        ])
-        .unwrap()
-        .fit;
-
-        assert_eq!(args.module_key.as_deref(), Some("module-key"));
-        assert_eq!(args.remote_key, "remote-key");
-        assert_eq!(args.ctx, Some(serde_json::json!({ "issueKey": "TEST-1" })));
-        assert_eq!(args.fct.as_deref(), Some("provided-fct"));
-        assert!(args.dry_run);
-        assert!(args.diagnostic_logging_requested());
+    fn accepts_fct_input_modes() {
+        assert!(TestArgs::try_parse_from(["fsrt", "remote-key", "--fct", "provided-fct"]).is_ok());
+        assert!(
+            TestArgs::try_parse_from(["fsrt", "remote-key", "--module", "module-key",]).is_ok()
+        );
+        assert!(
+            TestArgs::try_parse_from([
+                "fsrt",
+                "remote-key",
+                "--module",
+                "module-key",
+                "--ctx",
+                r#"{"issueKey":"TEST-1"}"#,
+            ])
+            .is_ok()
+        );
     }
 
     #[test]
-    fn omits_context_by_default() {
-        let args = TestArgs::try_parse_from(["fsrt", "module-key", "remote-key"])
-            .unwrap()
-            .fit;
-
-        assert_eq!(args.ctx, None);
-        assert_eq!(args.fct, None);
-        assert!(!args.diagnostic_logging_requested());
+    fn rejects_conflicting_fct_input_modes() {
+        for args in [
+            &[
+                "fsrt",
+                "remote-key",
+                "--fct",
+                "provided-fct",
+                "--module",
+                "module-key",
+            ][..],
+            &[
+                "fsrt",
+                "remote-key",
+                "--fct",
+                "provided-fct",
+                "--module",
+                "module-key",
+                "--ctx",
+                r#"{"issueKey":"TEST-1"}"#,
+            ][..],
+            &[
+                "fsrt",
+                "remote-key",
+                "--fct",
+                "provided-fct",
+                "--ctx",
+                r#"{"issueKey":"TEST-1"}"#,
+            ][..],
+        ] {
+            let error = TestArgs::try_parse_from(args).unwrap_err();
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 
     #[test]
-    fn module_key_is_optional_with_a_supplied_fct() {
-        let args = TestArgs::try_parse_from(["fsrt", "remote-key", "--fct", "provided-fct"])
-            .unwrap()
-            .fit;
-
-        assert_eq!(args.module_key, None);
-        assert_eq!(args.remote_key, "remote-key");
-        assert_eq!(args.fct.as_deref(), Some("provided-fct"));
-    }
-
-    #[test]
-    fn rejects_missing_keys_and_invalid_context_before_execution() {
+    fn rejects_incomplete_or_positional_module_inputs() {
         assert!(TestArgs::try_parse_from(["fsrt", "remote-key"]).is_err());
+        assert!(
+            TestArgs::try_parse_from(["fsrt", "remote-key", "--ctx", r#"{"issueKey":"TEST-1"}"#,])
+                .is_err()
+        );
         assert!(
             TestArgs::try_parse_from([
                 "fsrt",
@@ -149,12 +167,6 @@ mod tests {
             ])
             .is_err()
         );
-        for context in ["not-json", "[]", "null", r#""string""#] {
-            assert!(
-                TestArgs::try_parse_from(["fsrt", "module-key", "remote-key", "--ctx", context,])
-                    .is_err(),
-                "context unexpectedly accepted: {context}"
-            );
-        }
+        assert!(TestArgs::try_parse_from(["fsrt", "module-key", "remote-key"]).is_err());
     }
 }

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -61,12 +61,19 @@ pub(super) fn run(args: &MintFitArgs) -> Result<()> {
         return Ok(());
     }
 
-    let token = tester.mint_fit(
-        args.module_key.as_deref(),
-        &args.remote_key,
-        args.ctx.as_ref(),
-        args.fct.as_deref(),
-    )?;
+    let fct = if args.ctx.is_some() || args.fct.is_none() {
+        let module_key = args
+            .module_key
+            .as_deref()
+            .expect("clap requires MODULE_KEY when an FCT must be minted");
+        let ctx = args.ctx.clone().unwrap_or_else(|| serde_json::json!({}));
+        tester.mint_fct(module_key, &ctx)?
+    } else {
+        args.fct
+            .clone()
+            .expect("an FCT is present when minting is not required")
+    };
+    let token = tester.mint_fit(&args.remote_key, &fct)?;
     println!("{token}");
 
     Ok(())

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -1,0 +1,130 @@
+use std::{fs, path::PathBuf};
+
+use clap::{Args, ValueHint};
+use serde_json::Value;
+
+use crate::{Result, forge_project::find_manifest_path};
+
+use super::parse_ctx;
+
+const REDACTED_FCT: &str = "<FCT selected at runtime>";
+
+/// `mint-fit` arguments.
+#[derive(Args, Debug)]
+pub(crate) struct MintFitArgs {
+    /// Deployed module key used when an FCT must be minted.
+    #[arg(name = "MODULE_KEY")]
+    module_key: String,
+
+    /// Forge remote key to sign the invocation for.
+    #[arg(name = "REMOTE_KEY")]
+    remote_key: String,
+
+    /// Force a new FCT with this inline JSON object as its context.
+    #[arg(long = "ctx", value_parser = parse_ctx)]
+    ctx: Option<Value>,
+
+    /// Existing FCT to pass in.
+    #[arg(long)]
+    fct: Option<String>,
+
+    /// Forge app directory.
+    #[arg(long, default_value = ".", value_hint = ValueHint::DirPath)]
+    app_dir: PathBuf,
+
+    /// Path to `fsrt-remote.toml`.
+    #[arg(long, default_value = "./fsrt-remote.toml", value_hint = ValueHint::FilePath)]
+    config: PathBuf,
+
+    /// Authenticate, query metadata, and print redacted FIT variables without minting.
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+}
+
+impl MintFitArgs {
+    pub(super) fn diagnostic_logging_requested(&self) -> bool {
+        self.dry_run
+    }
+}
+
+pub(super) fn run(args: &MintFitArgs) -> Result<()> {
+    let manifest_path = find_manifest_path(&args.app_dir)?;
+    let manifest_text = fs::read_to_string(manifest_path)?;
+    let manifest: forge_loader::manifest::ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
+
+    let config = forge_pen_test::FsrtRemoteConfig::from_path(&args.config)?;
+    let tester = forge_pen_test::ForgePenTester::new(&manifest, config)?;
+    if args.dry_run {
+        let request = tester.mint_fit_request(&args.module_key, REDACTED_FCT, &args.remote_key)?;
+        println!("variables={:#}", request.variables);
+        return Ok(());
+    }
+
+    let token = tester.mint_fit(
+        &args.module_key,
+        &args.remote_key,
+        args.ctx.as_ref(),
+        args.fct.as_deref(),
+    )?;
+    println!("{}", token.jwt());
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestArgs {
+        #[command(flatten)]
+        fit: MintFitArgs,
+    }
+
+    #[test]
+    fn parses_required_keys_and_optional_fit_inputs() {
+        let args = TestArgs::try_parse_from([
+            "fsrt",
+            "module-key",
+            "remote-key",
+            "--ctx",
+            r#"{"issueKey":"TEST-1"}"#,
+            "--fct",
+            "provided-fct",
+            "--dry-run",
+        ])
+        .unwrap()
+        .fit;
+
+        assert_eq!(args.module_key, "module-key");
+        assert_eq!(args.remote_key, "remote-key");
+        assert_eq!(args.ctx, Some(serde_json::json!({ "issueKey": "TEST-1" })));
+        assert_eq!(args.fct.as_deref(), Some("provided-fct"));
+        assert!(args.dry_run);
+        assert!(args.diagnostic_logging_requested());
+    }
+
+    #[test]
+    fn omits_context_by_default() {
+        let args = TestArgs::try_parse_from(["fsrt", "module-key", "remote-key"])
+            .unwrap()
+            .fit;
+
+        assert_eq!(args.ctx, None);
+        assert_eq!(args.fct, None);
+        assert!(!args.diagnostic_logging_requested());
+    }
+
+    #[test]
+    fn rejects_missing_keys_and_invalid_context_before_execution() {
+        assert!(TestArgs::try_parse_from(["fsrt", "module-key"]).is_err());
+        for context in ["not-json", "[]", "null", r#""string""#] {
+            assert!(
+                TestArgs::try_parse_from(["fsrt", "module-key", "remote-key", "--ctx", context,])
+                    .is_err(),
+                "context unexpectedly accepted: {context}"
+            );
+        }
+    }
+}

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -11,17 +11,18 @@ const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
 /// `mint-fit` arguments.
 #[derive(Args, Debug)]
+#[command(allow_missing_positional = true)]
 pub(crate) struct MintFitArgs {
     /// Deployed module key used when an FCT must be minted.
-    #[arg(name = "MODULE_KEY")]
-    module_key: String,
+    #[arg(name = "MODULE_KEY", required_unless_present = "fct")]
+    module_key: Option<String>,
 
     /// Forge remote key to sign the invocation for.
     #[arg(name = "REMOTE_KEY")]
     remote_key: String,
 
     /// Force a new FCT with this inline JSON object as its context.
-    #[arg(long = "ctx", value_parser = parse_ctx)]
+    #[arg(long = "ctx", value_parser = parse_ctx, requires = "MODULE_KEY")]
     ctx: Option<Value>,
 
     /// Existing FCT to pass in.
@@ -55,13 +56,13 @@ pub(super) fn run(args: &MintFitArgs) -> Result<()> {
     let config = forge_pen_test::FsrtRemoteConfig::from_path(&args.config)?;
     let tester = forge_pen_test::ForgePenTester::new(&manifest, config)?;
     if args.dry_run {
-        let request = tester.mint_fit_request(&args.module_key, REDACTED_FCT, &args.remote_key)?;
+        let request = tester.mint_fit_request(REDACTED_FCT, &args.remote_key)?;
         println!("variables={:#}", request.variables);
         return Ok(());
     }
 
     let token = tester.mint_fit(
-        &args.module_key,
+        args.module_key.as_deref(),
         &args.remote_key,
         args.ctx.as_ref(),
         args.fct.as_deref(),
@@ -97,7 +98,7 @@ mod tests {
         .unwrap()
         .fit;
 
-        assert_eq!(args.module_key, "module-key");
+        assert_eq!(args.module_key.as_deref(), Some("module-key"));
         assert_eq!(args.remote_key, "remote-key");
         assert_eq!(args.ctx, Some(serde_json::json!({ "issueKey": "TEST-1" })));
         assert_eq!(args.fct.as_deref(), Some("provided-fct"));
@@ -117,8 +118,30 @@ mod tests {
     }
 
     #[test]
+    fn module_key_is_optional_with_a_supplied_fct() {
+        let args = TestArgs::try_parse_from(["fsrt", "remote-key", "--fct", "provided-fct"])
+            .unwrap()
+            .fit;
+
+        assert_eq!(args.module_key, None);
+        assert_eq!(args.remote_key, "remote-key");
+        assert_eq!(args.fct.as_deref(), Some("provided-fct"));
+    }
+
+    #[test]
     fn rejects_missing_keys_and_invalid_context_before_execution() {
-        assert!(TestArgs::try_parse_from(["fsrt", "module-key"]).is_err());
+        assert!(TestArgs::try_parse_from(["fsrt", "remote-key"]).is_err());
+        assert!(
+            TestArgs::try_parse_from([
+                "fsrt",
+                "remote-key",
+                "--ctx",
+                r#"{"issueKey":"TEST-1"}"#,
+                "--fct",
+                "provided-fct",
+            ])
+            .is_err()
+        );
         for context in ["not-json", "[]", "null", r#""string""#] {
             assert!(
                 TestArgs::try_parse_from(["fsrt", "module-key", "remote-key", "--ctx", context,])

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -66,7 +66,7 @@ pub(super) fn run(args: &MintFitArgs) -> Result<()> {
         args.ctx.as_ref(),
         args.fct.as_deref(),
     )?;
-    println!("{}", token.jwt());
+    println!("{token}");
 
     Ok(())
 }

--- a/crates/fsrt/src/commands/mod.rs
+++ b/crates/fsrt/src/commands/mod.rs
@@ -3,24 +3,41 @@ use clap::Subcommand;
 use crate::Result;
 
 pub(crate) mod mint_fct;
+pub(crate) mod mint_fit;
+
+fn parse_ctx(value: &str) -> std::result::Result<serde_json::Value, String> {
+    let ctx: serde_json::Value =
+        serde_json::from_str(value).map_err(|error| format!("invalid JSON: {error}"))?;
+
+    if !ctx.is_object() {
+        return Err("ctx must be a JSON object".to_string());
+    }
+
+    Ok(ctx)
+}
 
 /// CLI subcommands.
 #[derive(Subcommand, Debug)]
 pub(crate) enum Command {
     /// Mint an FCT for a deployed module.
     MintFct(mint_fct::MintFctArgs),
+
+    /// Mint a FIT for a deployed module and Forge remote.
+    MintFit(mint_fit::MintFitArgs),
 }
 
 impl Command {
     pub(crate) fn diagnostic_logging_requested(&self) -> bool {
         match self {
             Self::MintFct(args) => args.diagnostic_logging_requested(),
+            Self::MintFit(args) => args.diagnostic_logging_requested(),
         }
     }
 
     pub(crate) fn run(&self) -> Result<()> {
         match self {
             Self::MintFct(args) => mint_fct::run(args),
+            Self::MintFit(args) => mint_fit::run(args),
         }
     }
 }


### PR DESCRIPTION
**Summary**

- This adds end-to-end support for minting Forge Invocation Tokens (FITs):
  - Exposes remote keys from Forge manifests
  - Adds reusable FIT request and minting APIs to forge_pen_test
  - Adds fsrt mint-fit <MODULE_KEY> <REMOTE_KEY>
  - Supports supplied, cached, or newly minted FCTs
  - Supports custom FCT context with --ctx
  - Adds dry-run output, input validation, tests, and documentation

Note: The cache is not persistent. Look into automatic disk cache or other solutions, but this will probably be another PR.