### PR TITLE
Amendments to invoke-extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ cargo install --git https://github.com/atlassian-labs/FSRT --locked
 
 ```text
 fsrt mint-fct <MODULE_KEY> [OPTIONS]
-fsrt mint-fit <REMOTE_KEY> [--module <MODULE_KEY>] [OPTIONS]
-fsrt invoke-extension <MODULE_KEY> <FUNCTION> <PAYLOAD> [OPTIONS]
+fsrt mint-fit <REMOTE_KEY> (--module <MODULE_KEY> | --fct <FCT>) [OPTIONS]
+fsrt invoke-extension <FUNCTION> <MODULE_KEY> [--fct <FCT>] [OPTIONS]
 ```
 
 All three commands use `--app-dir` and a TOML configuration file; see
@@ -84,11 +84,13 @@ selected extension's `context` object.
 | Use an existing FCT | `<REMOTE_KEY> --fct <FCT>` | Uses the supplied FCT when `--module` and `--ctx` are omitted. |
 | Mint a new FCT | `<REMOTE_KEY> --module <MODULE_KEY>` | Mints an FCT with an empty context, then uses it to mint the FIT. Add `--ctx '<JSON>'` to set its context. |
 
-`invoke-extension` invokes a resolver with tester-controlled JSON. Its positional arguments
-select the deployed module, resolver function, and invocation payload. By default it derives
-the invocation context from deployment metadata and mints an FCT in memory. Use
-`--ctx '<JSON>'` to replace that context or `--fct <JWT>` to reuse a captured token.
-`--async` requests an asynchronous invocation when supported.
+`invoke-extension` always resolves its request target from `<MODULE_KEY>`. The FCT only supplies
+the request's context token.
+
+| Mode | Required inputs | Behavior |
+| --- | --- | --- |
+| Use an existing FCT | `<FUNCTION> <MODULE_KEY> --fct <FCT>` | Builds the request from the selected deployed module and uses the supplied FCT only as its context token. |
+| Mint a new FCT | `<FUNCTION> <MODULE_KEY>` | Calls `mint_fct` for the selected module, then invokes it. Add `--ctx '<JSON>'` to use that context for both operations. |
 
 By default, live mint commands print only the token, while `invoke-extension` prints the
 backend response. `--dry-run` queries metadata without signing tokens or invoking the

--- a/crates/forge_pen_test/src/app_config.rs
+++ b/crates/forge_pen_test/src/app_config.rs
@@ -2,7 +2,7 @@
 
 use tracing::warn;
 
-use crate::mint_common::MintError;
+use crate::mint_common::PenTestError;
 
 /// A deployed Forge extension available for FCT minting.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,13 +79,13 @@ impl AppConfig {
     pub fn extension_for_module_key(
         &self,
         module_key: &str,
-    ) -> Result<&ExtensionConfig, MintError> {
+    ) -> Result<&ExtensionConfig, PenTestError> {
         let mut matches = self
             .extensions
             .iter()
             .filter(|extension| extension.module_key == module_key);
         let Some(first) = matches.next() else {
-            return Err(MintError::ModuleKeyNotFound {
+            return Err(PenTestError::ModuleKeyNotFound {
                 module_key: module_key.to_string(),
                 available: self
                     .extensions
@@ -167,7 +167,7 @@ mod tests {
         assert!(matches!(
             config(vec![extension("none", "extension-1")])
                 .extension_for_module_key("missing"),
-            Err(MintError::ModuleKeyNotFound { module_key, available })
+            Err(PenTestError::ModuleKeyNotFound { module_key, available })
                 if module_key == "missing" && available == ["none"]
         ));
     }

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::app_config::{AppConfig, ExtensionConfig};
 use crate::fsrt_remote_config::FsrtRemoteConfig;
 use crate::mint_common::{
-    GraphqlErrorObject, GraphqlHeaders, GraphqlRequest, JwtValidity, MintError,
+    GraphqlErrorObject, GraphqlHeaders, GraphqlRequest, JwtValidity, PenTestError,
     build_cookie_header, decode_jwt_payload, fetch_cloud_id, post_graphql,
 };
 
@@ -209,7 +209,7 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
     pub fn new(
         manifest: &'manifest ForgeManifest<'source>,
         file_config: FsrtRemoteConfig,
-    ) -> Result<Self, MintError> {
+    ) -> Result<Self, PenTestError> {
         let FsrtRemoteConfig {
             site,
             auth,
@@ -220,8 +220,10 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             .map(EnvironmentSelection::Key)
             .unwrap_or(EnvironmentSelection::Automatic);
         let app_id = manifest.app.id.to_string();
+        let mut graphql_endpoint = site.clone();
+        graphql_endpoint.set_path("/gateway/api/graphql");
         let cookie_header = build_cookie_header(&auth.raw_cookie_file)?;
-        let headers = GraphqlHeaders::new(cookie_header)?;
+        let headers = GraphqlHeaders::new(cookie_header, &graphql_endpoint)?;
         let agent = Agent::config_builder()
             .timeout_global(Some(std::time::Duration::from_secs(30)))
             .http_status_as_error(false)
@@ -240,7 +242,7 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
                 "appId": &app_id
             }),
         };
-        let data: AppsData = post_graphql(&agent, &apps_request)?;
+        let data: AppsData = post_graphql(&agent, &graphql_endpoint, &apps_request)?;
         let config = resolve_app_config(data, &context_id, &app_id, environment)?;
         info!(
             product = ?product,
@@ -269,11 +271,6 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         self.manifest
     }
 
-    /// Returns the Atlassian site used to resolve the deployment context.
-    pub fn site(&self) -> &Url {
-        &self.site
-    }
-
     /// Returns the cached FCT when structurally valid and unexpired.
     /// An empty cache is reported as [`JwtValidity::Invalid`].
     /// The signature is not cryptographically verified.
@@ -299,9 +296,9 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         &self,
         module_key: &str,
         ctx: &serde_json::Value,
-    ) -> Result<GraphqlRequest<serde_json::Value>, MintError> {
+    ) -> Result<GraphqlRequest<serde_json::Value>, PenTestError> {
         if !ctx.is_object() {
-            return Err(MintError::InvalidFctContext);
+            return Err(PenTestError::InvalidFctContext);
         }
         let extension = self.config.extension_for_module_key(module_key)?;
         info!(
@@ -332,17 +329,26 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
     /// Sends a GraphQL mutation and returns its required, generic data object.
     ///
     /// A non-empty top-level `errors` list is returned unchanged in
-    /// [`MintError::GraphqlRejected`].
-    pub fn post_graphql_mutation<V, T>(&self, request: &GraphqlRequest<V>) -> Result<T, MintError>
+    /// [`PenTestError::GraphqlRejected`].
+    pub fn post_graphql_mutation<V, T>(
+        &self,
+        request: &GraphqlRequest<V>,
+    ) -> Result<T, PenTestError>
     where
         V: serde::Serialize,
         T: serde::de::DeserializeOwned,
     {
-        post_graphql(&self.agent, request)
+        let mut graphql_endpoint = self.site.clone();
+        graphql_endpoint.set_path("/gateway/api/graphql");
+        post_graphql(&self.agent, &graphql_endpoint, request)
     }
 
     /// Mints a new FCT and replaces the cache only on success.
-    pub fn mint_fct(&self, module_key: &str, ctx: &serde_json::Value) -> Result<String, MintError> {
+    pub fn mint_fct(
+        &self,
+        module_key: &str,
+        ctx: &serde_json::Value,
+    ) -> Result<String, PenTestError> {
         let request = self.mint_fct_request(module_key, ctx)?;
         let variables = format!("{:#}", request.variables);
         info!(variables = %variables, "FCT GraphQL variables");
@@ -353,14 +359,14 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             tokens,
         } = data.result;
         if !success || !errors.is_empty() {
-            return Err(MintError::MintRejected { success, errors });
+            return Err(PenTestError::MintRejected { success, errors });
         }
 
         let jwt = tokens
             .into_iter()
             .next()
             .map(|token| token.jwt)
-            .ok_or(MintError::MissingFctToken)?;
+            .ok_or(PenTestError::MissingFctToken)?;
         self.cached_fct_jwt.borrow_mut().clone_from(&jwt);
         debug!("successfully minted Forge Context Token");
         Ok(jwt)
@@ -371,9 +377,9 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         &self,
         fct: &str,
         remote_key: &str,
-    ) -> Result<GraphqlRequest<serde_json::Value>, MintError> {
+    ) -> Result<GraphqlRequest<serde_json::Value>, PenTestError> {
         if fct.trim().is_empty() {
-            return Err(MintError::EmptySuppliedFct);
+            return Err(PenTestError::EmptySuppliedFct);
         }
 
         Ok(GraphqlRequest {
@@ -389,7 +395,7 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
     }
 
     /// Mints a FIT for a Forge remote using the supplied FCT.
-    pub fn mint_fit(&self, remote_key: &str, fct: &str) -> Result<String, MintError> {
+    pub fn mint_fit(&self, remote_key: &str, fct: &str) -> Result<String, PenTestError> {
         let request = self.mint_fit_request(fct, remote_key)?;
         let mut variables = request.variables.clone();
         variables["input"]["forgeContextToken"] = REDACTED_FCT.into();
@@ -404,9 +410,9 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             data.result
                 .and_then(|result| result.token)
                 .map(|token| token.jwt)
-                .ok_or(MintError::MissingFitToken)
+                .ok_or(PenTestError::MissingFitToken)
         })()
-        .map_err(|source| MintError::FitMintFailed {
+        .map_err(|source| PenTestError::FitMintFailed {
             source: Box::new(source),
             available: self.config.remote_keys(),
         })?;
@@ -420,7 +426,7 @@ fn resolve_app_config(
     context_id: &str,
     app_id: &str,
     environment: EnvironmentSelection,
-) -> Result<AppConfig, MintError> {
+) -> Result<AppConfig, PenTestError> {
     let app = data
         .ecosystem
         .apps_installed_in_contexts
@@ -428,7 +434,7 @@ fn resolve_app_config(
         .into_iter()
         .map(|edge| edge.node)
         .find(|app| app.id == app_id)
-        .ok_or_else(|| MintError::AppNotInstalled {
+        .ok_or_else(|| PenTestError::AppNotInstalled {
             app_id: app_id.to_string(),
             context_id: context_id.to_string(),
         })?;
@@ -436,11 +442,11 @@ fn resolve_app_config(
     let app_id_bare = app
         .id
         .strip_prefix("ari:cloud:ecosystem::app/")
-        .ok_or_else(|| MintError::InvalidAppId {
+        .ok_or_else(|| PenTestError::InvalidAppId {
             app_id: app.id.clone(),
         })?;
     if installations.is_empty() {
-        return Err(MintError::NoInstallations {
+        return Err(PenTestError::NoInstallations {
             app_id: app_id.to_string(),
             context_id: context_id.to_string(),
         });
@@ -468,7 +474,7 @@ fn resolve_app_config(
             Some(key) => installations
                 .into_iter()
                 .find(|installation| installation.app_environment.key == key)
-                .ok_or_else(|| MintError::EnvironmentNotFound {
+                .ok_or_else(|| PenTestError::EnvironmentNotFound {
                     environment_key: key.to_string(),
                     app_id: app_id.to_string(),
                 })?,
@@ -511,11 +517,6 @@ fn resolve_app_config(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
     use super::*;
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use ureq::{
@@ -588,34 +589,6 @@ mod tests {
             .into()
     }
 
-    fn response_sequence_agent(bodies: &[&str]) -> (Agent, Arc<AtomicUsize>) {
-        let bodies = bodies
-            .iter()
-            .map(|body| body.to_string())
-            .collect::<Vec<_>>();
-        let request_count = Arc::new(AtomicUsize::new(0));
-        let request_count_for_agent = Arc::clone(&request_count);
-        let agent = Agent::config_builder()
-            .http_status_as_error(false)
-            .middleware(
-                move |_request: Request<SendBody<'_>>, _next: MiddlewareNext<'_>| {
-                    let index = request_count_for_agent.fetch_add(1, Ordering::SeqCst);
-                    let body = bodies
-                        .get(index)
-                        .cloned()
-                        .unwrap_or_else(|| panic!("unexpected request {index}"));
-                    Ok(Response::builder()
-                        .status(200)
-                        .header("Content-Type", "application/json")
-                        .body(Body::builder().data(body))
-                        .unwrap())
-                },
-            )
-            .build()
-            .into();
-        (agent, request_count)
-    }
-
     fn installation(id: &str, environment: &str) -> serde_json::Value {
         serde_json::json!({
             "id": id,
@@ -637,7 +610,7 @@ mod tests {
     fn resolve(
         installations: &[(&str, &str)],
         environment: EnvironmentSelection,
-    ) -> Result<AppConfig, MintError> {
+    ) -> Result<AppConfig, PenTestError> {
         let installations = installations
             .iter()
             .map(|&(id, environment)| installation(id, environment))
@@ -720,7 +693,7 @@ mod tests {
         );
         assert!(matches!(
             tester.mint_fct_request("installation-1-module", &serde_json::json!([])),
-            Err(MintError::InvalidFctContext)
+            Err(PenTestError::InvalidFctContext)
         ));
     }
 
@@ -745,14 +718,14 @@ mod tests {
 
         assert!(matches!(
             resolve(&[], Automatic),
-            Err(MintError::NoInstallations { .. })
+            Err(PenTestError::NoInstallations { .. })
         ));
         assert!(matches!(
             resolve(
                 &[("production", "production"), ("default", "default")],
                 Key("staging".into())
             ),
-            Err(MintError::EnvironmentNotFound { .. })
+            Err(PenTestError::EnvironmentNotFound { .. })
         ));
     }
 
@@ -774,9 +747,9 @@ mod tests {
     }
 
     #[test]
-    fn builds_fit_request() {
+    fn builds_fit_request_without_changing_the_fct() {
         let request = tester()
-            .mint_fit_request("fct", "not-declared-in-manifest")
+            .mint_fit_request(" fct ", "not-declared-in-manifest")
             .unwrap();
 
         assert_eq!(request.operation_name, FIT_OPERATION_NAME);
@@ -785,179 +758,11 @@ mod tests {
             request.variables,
             serde_json::json!({
                 "input": {
-                    "forgeContextToken": "fct",
+                    "forgeContextToken": " fct ",
                     "remoteKey": "not-declared-in-manifest"
                 }
             })
         );
-    }
-
-    #[test]
-    fn builds_default_invoke_context_and_request() {
-        let tester = tester();
-        let ctx = tester.default_invoke_context("module").unwrap();
-
-        assert_eq!(
-            ctx,
-            serde_json::json!({
-                "appVersion": "1.0.0",
-                "cloudId": "cloud-1",
-                "environmentId": "environment-1",
-                "extension": { "type": "jira:issuePanel" },
-                "moduleKey": "module",
-                "siteUrl": "https://example.atlassian.net/",
-            })
-        );
-
-        let payload = serde_json::json!({ "issueId": "10001" });
-        let request = tester
-            .invoke_extension_request("module", " resolver-fn ", &payload, &ctx, "fct", true)
-            .unwrap();
-
-        assert_eq!(request.operation_name, "InvokeExtension");
-        assert!(request.query.contains("invokeExtension(input: $input)"));
-        assert_eq!(
-            request.variables,
-            serde_json::json!({
-                "input": {
-                    "async": true,
-                    "contextIds": [CONTEXT_ID],
-                    "entryPoint": "resolver",
-                    "extensionId": "ari:cloud:ecosystem::extension/app-1/environment-1/static/module",
-                    "payload": {
-                        "call": {
-                            "functionKey": "resolver-fn",
-                            "payload": payload,
-                        },
-                        "context": ctx,
-                        "contextToken": "fct",
-                    }
-                }
-            })
-        );
-    }
-
-    #[test]
-    fn invoke_request_rejects_invalid_inputs() {
-        let tester = tester();
-        let payload = serde_json::json!({});
-        let ctx = serde_json::json!({});
-
-        assert!(matches!(
-            tester.invoke_extension_request("module", "  ", &payload, &ctx, "fct", false),
-            Err(MintError::InvocationFailed(_))
-        ));
-        assert!(matches!(
-            tester.invoke_extension_request(
-                "module",
-                "resolver-fn",
-                &payload,
-                &serde_json::json!([]),
-                "fct",
-                false,
-            ),
-            Err(MintError::InvalidFctContext)
-        ));
-        assert!(matches!(
-            tester.invoke_extension_request("module", "resolver-fn", &payload, &ctx, " ", false),
-            Err(MintError::EmptySuppliedFct)
-        ));
-    }
-
-    #[test]
-    fn invoke_extension_accepts_null_errors_and_returns_response() {
-        let mut tester = tester();
-        tester.agent = response_agent(
-            200,
-            r#"{"data":{"invokeExtension":{"success":true,"errors":null,"response":{"body":{"ok":true}}}}}"#,
-        );
-
-        let outcome = tester
-            .invoke_extension(
-                "module",
-                "resolver-fn",
-                &serde_json::json!({}),
-                &serde_json::json!({}),
-                Some("provided-fct"),
-                false,
-            )
-            .unwrap();
-
-        assert_eq!(
-            outcome.response(),
-            Some(&serde_json::json!({ "body": { "ok": true } }))
-        );
-    }
-
-    #[test]
-    fn invoke_extension_mints_an_fct_when_none_is_supplied() {
-        let mut tester = tester();
-        let (agent, request_count) = response_sequence_agent(&[
-            r#"{"data":{"globalApp_signForgeContextTokens":{"success":true,"errors":[],"tokens":[{"jwt":"minted-fct"}]}}}"#,
-            r#"{"data":{"invokeExtension":{"success":true,"errors":[],"response":null}}}"#,
-        ]);
-        tester.agent = agent;
-
-        let outcome = tester
-            .invoke_extension(
-                "module",
-                "resolver-fn",
-                &serde_json::json!({}),
-                &serde_json::json!({ "issueKey": "TEST-1" }),
-                None,
-                false,
-            )
-            .unwrap();
-
-        assert_eq!(outcome.response(), None);
-        assert_eq!(request_count.load(Ordering::SeqCst), 2);
-    }
-
-    #[test]
-    fn invoke_extension_reports_unsuccessful_and_missing_results() {
-        for (body, expected) in [
-            (
-                r#"{"data":{"invokeExtension":{"success":false,"errors":[{"message":"denied"}],"response":null}}}"#,
-                "denied",
-            ),
-            (
-                r#"{"data":{"invokeExtension":null}}"#,
-                "response missing data.invokeExtension",
-            ),
-            (
-                r#"{"data":{"invokeExtension":{"success":false,"errors":null,"response":null}}}"#,
-                "without an error message",
-            ),
-        ] {
-            let mut tester = tester();
-            tester.agent = response_agent(200, body);
-            let error = tester
-                .invoke_extension(
-                    "module",
-                    "resolver-fn",
-                    &serde_json::json!({}),
-                    &serde_json::json!({}),
-                    Some("provided-fct"),
-                    false,
-                )
-                .unwrap_err();
-
-            assert!(error.to_string().contains(expected), "{error}");
-        }
-    }
-
-    #[test]
-    fn rejects_an_empty_fct_without_wrapping_it_as_a_fit_failure() {
-        let tester = tester();
-
-        assert!(matches!(
-            tester.mint_fit_request("  ", "remote"),
-            Err(MintError::EmptySuppliedFct)
-        ));
-        assert!(matches!(
-            tester.mint_fit("remote", "  "),
-            Err(MintError::EmptySuppliedFct)
-        ));
     }
 
     #[test]
@@ -974,13 +779,13 @@ mod tests {
             .mint_fit("not-declared-in-manifest", "provided-fct")
             .unwrap_err();
         let display = error.to_string();
-        let MintError::FitMintFailed { source, available } = error else {
+        let PenTestError::FitMintFailed { source, available } = error else {
             panic!("unexpected error variant")
         };
 
         assert!(matches!(
             source.as_ref(),
-            MintError::GraphqlRejected { errors, .. }
+            PenTestError::GraphqlRejected { errors, .. }
                 if errors.first().and_then(|error| error.message.as_deref())
                     == Some("unknown remote")
         ));

--- a/crates/forge_pen_test/src/fsrt_remote_config.rs
+++ b/crates/forge_pen_test/src/fsrt_remote_config.rs
@@ -5,7 +5,7 @@ use std::{fs, path::Path};
 use serde::{Deserialize, Deserializer, de::Error as _};
 use url::Url;
 
-use crate::mint_common::MintError;
+use crate::mint_common::PenTestError;
 
 /// Untrusted configuration loaded from `fsrt-remote.toml`.
 #[derive(Debug, Deserialize)]
@@ -35,13 +35,14 @@ pub struct AuthConfig {
 
 impl FsrtRemoteConfig {
     /// Loads untrusted configuration from a TOML file.
-    pub fn from_path(config_path: &Path) -> Result<Self, MintError> {
-        let contents = fs::read_to_string(config_path).map_err(|source| MintError::FileRead {
-            kind: "config",
-            path: config_path.to_path_buf(),
-            source,
-        })?;
-        toml::from_str(&contents).map_err(|source| MintError::ConfigParse {
+    pub fn from_path(config_path: &Path) -> Result<Self, PenTestError> {
+        let contents =
+            fs::read_to_string(config_path).map_err(|source| PenTestError::FileRead {
+                kind: "config",
+                path: config_path.to_path_buf(),
+                source,
+            })?;
+        toml::from_str(&contents).map_err(|source| PenTestError::ConfigParse {
             path: config_path.to_path_buf(),
             source,
         })

--- a/crates/forge_pen_test/src/fsrt_remote_config.rs
+++ b/crates/forge_pen_test/src/fsrt_remote_config.rs
@@ -56,7 +56,9 @@ where
     let input = String::deserialize(deserializer)?;
     let site = Url::parse(&input).map_err(D::Error::custom)?;
     let valid = site.scheme() == "https"
-        && site.host_str().is_some()
+        && site.host_str().is_some_and(|host| {
+            host.ends_with(".atlassian.net") || host.ends_with(".jira-dev.com")
+        })
         && site.username().is_empty()
         && site.password().is_none()
         && site.path() == "/"
@@ -64,49 +66,9 @@ where
         && site.fragment().is_none();
     if !valid {
         return Err(D::Error::custom(
-            "site must be an HTTPS URL without credentials, a path, query, or fragment",
+            "site must be an HTTPS *.atlassian.net or *.jira-dev.com origin without credentials, a path, query, or fragment",
         ));
     }
 
     Ok(site)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn parse(site: &str) -> Result<FsrtRemoteConfig, toml::de::Error> {
-        toml::from_str(&format!(
-            r#"site = "{site}"
-product = "jira"
-[auth]
-raw_cookie_file = "./session-cookie.txt"
-"#
-        ))
-    }
-
-    #[test]
-    fn site_accepts_any_https_host_and_an_explicit_port() {
-        for site in [
-            "https://foo.jira-dev.com",
-            "https://example.atlassian.net/",
-            "https://localhost:8443",
-        ] {
-            assert_eq!(parse(site).unwrap().site, Url::parse(site).unwrap());
-        }
-    }
-
-    #[test]
-    fn site_rejects_non_https_and_non_origin_urls() {
-        for site in [
-            "http://example.com",
-            "example.com",
-            "https://user@example.com",
-            "https://example.com/path",
-            "https://example.com?query=value",
-            "https://example.com#fragment",
-        ] {
-            assert!(parse(site).is_err(), "site unexpectedly accepted: {site}");
-        }
-    }
 }

--- a/crates/forge_pen_test/src/invoke.rs
+++ b/crates/forge_pen_test/src/invoke.rs
@@ -3,7 +3,7 @@
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use crate::{ForgePenTester, GraphqlErrorObject, GraphqlRequest, MintError};
+use crate::{ForgePenTester, GraphqlErrorObject, GraphqlRequest, PenTestError};
 
 const INVOKE_MUTATION: &str = r#"mutation InvokeExtension($input: InvokeExtensionInput!) {
   invokeExtension(input: $input) {
@@ -19,7 +19,6 @@ const INVOKE_MUTATION: &str = r#"mutation InvokeExtension($input: InvokeExtensio
 
 const INVOKE_OPERATION_NAME: &str = "InvokeExtension";
 const RESOLVER_ENTRY_POINT: &str = "resolver";
-const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
 #[derive(Debug, Deserialize)]
 struct InvokeData {
@@ -31,17 +30,8 @@ struct InvokeData {
 struct InvokeResult {
     #[serde(default)]
     success: bool,
-    #[serde(default, deserialize_with = "deserialize_null_vec")]
-    errors: Vec<GraphqlErrorObject>,
+    errors: Option<Vec<GraphqlErrorObject>>,
     response: Option<JsonValue>,
-}
-
-fn deserialize_null_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: Deserialize<'de>,
-{
-    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// Successful `invokeExtension` response.
@@ -58,65 +48,24 @@ impl InvocationOutcome {
 }
 
 impl ForgePenTester<'_, '_> {
-    /// Builds a default invocation context from the resolved deployment.
-    pub fn default_invoke_context(&self, module_key: &str) -> Result<JsonValue, MintError> {
-        let extension = self.config().extension_for_module_key(module_key)?;
-        let cloud_id = self
-            .config()
-            .context_id()
-            .split_once("::site/")
-            .map(|(_, cloud_id)| cloud_id)
-            .filter(|cloud_id| !cloud_id.is_empty())
-            .ok_or_else(|| {
-                MintError::InvocationFailed(format!(
-                    "could not derive cloud ID from context '{}'",
-                    self.config().context_id()
-                ))
-            })?;
-        let environment_id = extension
-            .extension_id()
-            .strip_prefix("ari:cloud:ecosystem::extension/")
-            .and_then(|value| value.split('/').nth(1))
-            .filter(|environment_id| !environment_id.is_empty())
-            .ok_or_else(|| {
-                MintError::InvocationFailed(format!(
-                    "could not derive environment ID from extension '{}'",
-                    extension.extension_id()
-                ))
-            })?;
-
-        Ok(serde_json::json!({
-            "appVersion": self.config().app_version(),
-            "cloudId": cloud_id,
-            "environmentId": environment_id,
-            "extension": { "type": extension.extension_type() },
-            "moduleKey": extension.module_key(),
-            "siteUrl": self.site().as_str(),
-        }))
-    }
-
-    /// Constructs the exact GraphQL request used to invoke an extension.
+    /// Constructs the exact GraphQL request used to invoke a deployed module.
     pub fn invoke_extension_request(
         &self,
         module_key: &str,
         function_key: &str,
-        extension_payload: &JsonValue,
+        extension_payload: Option<&JsonValue>,
         ctx: &JsonValue,
         context_token: &str,
-        invoke_async: bool,
-    ) -> Result<GraphqlRequest<JsonValue>, MintError> {
-        let extension = self.config().extension_for_module_key(module_key)?;
-        let function_key = function_key.trim();
-        if function_key.is_empty() {
-            return Err(MintError::InvocationFailed(
-                "resolver function key must not be empty".to_string(),
-            ));
-        }
-        if !ctx.is_object() {
-            return Err(MintError::InvalidFctContext);
-        }
+    ) -> Result<GraphqlRequest<JsonValue>, PenTestError> {
         if context_token.trim().is_empty() {
-            return Err(MintError::EmptySuppliedFct);
+            return Err(PenTestError::EmptySuppliedFct);
+        }
+        let extension = self.config().extension_for_module_key(module_key)?;
+        let mut call = serde_json::json!({ "functionKey": function_key });
+        if let Some(extension_payload) = extension_payload {
+            call.as_object_mut()
+                .expect("resolver call must be a JSON object")
+                .insert("payload".to_string(), extension_payload.clone());
         }
 
         Ok(GraphqlRequest {
@@ -124,15 +73,11 @@ impl ForgePenTester<'_, '_> {
             query: INVOKE_MUTATION.to_string(),
             variables: serde_json::json!({
                 "input": {
-                    "async": invoke_async,
                     "contextIds": [self.config().context_id()],
                     "entryPoint": RESOLVER_ENTRY_POINT,
                     "extensionId": extension.extension_id(),
                     "payload": {
-                        "call": {
-                            "functionKey": function_key,
-                            "payload": extension_payload,
-                        },
+                        "call": call,
                         "context": ctx,
                         "contextToken": context_token,
                     }
@@ -141,56 +86,33 @@ impl ForgePenTester<'_, '_> {
         })
     }
 
-    /// Mints or reuses an FCT and invokes a resolver-backed extension.
+    /// Invokes a resolver-backed extension with an existing FCT.
     pub fn invoke_extension(
         &self,
         module_key: &str,
         function_key: &str,
-        extension_payload: &JsonValue,
+        extension_payload: Option<&JsonValue>,
         ctx: &JsonValue,
-        context_token: Option<&str>,
-        invoke_async: bool,
-    ) -> Result<InvocationOutcome, MintError> {
-        let request = match context_token {
-            Some(context_token) => self.invoke_extension_request(
-                module_key,
-                function_key,
-                extension_payload,
-                ctx,
-                context_token,
-                invoke_async,
-            )?,
-            None => {
-                self.invoke_extension_request(
-                    module_key,
-                    function_key,
-                    extension_payload,
-                    ctx,
-                    REDACTED_FCT,
-                    invoke_async,
-                )?;
-                let context_token = self.mint_fct(module_key, ctx)?;
-                self.invoke_extension_request(
-                    module_key,
-                    function_key,
-                    extension_payload,
-                    ctx,
-                    &context_token,
-                    invoke_async,
-                )?
-            }
-        };
+        context_token: &str,
+    ) -> Result<InvocationOutcome, PenTestError> {
+        let request = self.invoke_extension_request(
+            module_key,
+            function_key,
+            extension_payload,
+            ctx,
+            context_token,
+        )?;
         let data: InvokeData = self.post_graphql_mutation(&request)?;
         let result = data.result.ok_or_else(|| {
-            MintError::InvocationFailed("response missing data.invokeExtension".to_string())
+            PenTestError::InvocationFailed("response missing data.invokeExtension".to_string())
         })?;
-        if !result.success || !result.errors.is_empty() {
-            let messages = result
-                .errors
+        let errors = result.errors.unwrap_or_default();
+        if !result.success || !errors.is_empty() {
+            let messages = errors
                 .into_iter()
                 .filter_map(|error| error.message)
                 .collect::<Vec<_>>();
-            return Err(MintError::InvocationFailed(if messages.is_empty() {
+            return Err(PenTestError::InvocationFailed(if messages.is_empty() {
                 "server returned an unsuccessful result without an error message".to_string()
             } else {
                 messages.join("; ")

--- a/crates/forge_pen_test/src/invoke.rs
+++ b/crates/forge_pen_test/src/invoke.rs
@@ -2,6 +2,7 @@
 
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
+use tracing::info;
 
 use crate::{ForgePenTester, GraphqlErrorObject, GraphqlRequest, PenTestError};
 
@@ -61,6 +62,9 @@ impl ForgePenTester<'_, '_> {
             return Err(PenTestError::EmptySuppliedFct);
         }
         let extension = self.config().extension_for_module_key(module_key)?;
+        let function_key = function_key
+            .strip_prefix("resolver.")
+            .unwrap_or(function_key);
         let mut call = serde_json::json!({ "functionKey": function_key });
         if let Some(extension_payload) = extension_payload {
             call.as_object_mut()
@@ -102,6 +106,12 @@ impl ForgePenTester<'_, '_> {
             ctx,
             context_token,
         )?;
+        let variables = format!("{:#}", request.variables);
+        info!(
+            operation_name = INVOKE_OPERATION_NAME,
+            variables = %variables,
+            "InvokeExtension GraphQL variables"
+        );
         let data: InvokeData = self.post_graphql_mutation(&request)?;
         let result = data.result.ok_or_else(|| {
             PenTestError::InvocationFailed("response missing data.invokeExtension".to_string())

--- a/crates/forge_pen_test/src/lib.rs
+++ b/crates/forge_pen_test/src/lib.rs
@@ -10,4 +10,4 @@ pub use app_config::{AppConfig, ExtensionConfig};
 pub use forge_pentester::ForgePenTester;
 pub use fsrt_remote_config::{AuthConfig, FsrtRemoteConfig};
 pub use invoke::InvocationOutcome;
-pub use mint_common::{GraphqlErrorObject, GraphqlRequest, JwtValidity, MintError};
+pub use mint_common::{GraphqlErrorObject, GraphqlRequest, JwtValidity, PenTestError};

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -16,7 +16,6 @@ use ureq::{
 use url::Url;
 
 const SESSION_COOKIE_NAME: &str = "tenant.session.token";
-const GRAPHQL_ENDPOINT: &str = "https://www.atlassian.net/gateway/api/graphql";
 const GRAPHQL_ORIGIN: &str = "https://www.atlassian.net";
 
 /// A serialized GraphQL request shared by dry-run and live operations.
@@ -35,9 +34,9 @@ pub struct GraphqlErrorObject {
     pub message: Option<String>,
 }
 
-/// Errors produced while constructing or minting Forge tokens.
+/// Errors produced by Forge penetration-testing operations.
 #[derive(Debug, thiserror::Error)]
-pub enum MintError {
+pub enum PenTestError {
     #[error("could not read {kind} file '{path}'")]
     FileRead {
         kind: &'static str,
@@ -152,7 +151,7 @@ pub enum MintError {
     #[error("FIT minting failed: {source}; possible remotes: {available:?}")]
     FitMintFailed {
         #[source]
-        source: Box<MintError>,
+        source: Box<PenTestError>,
         available: Vec<String>,
     },
 
@@ -207,13 +206,17 @@ struct GraphqlData<T> {
 
 pub(crate) struct GraphqlHeaders {
     cookie: HeaderValue,
+    graphql_endpoint: String,
 }
 
 impl GraphqlHeaders {
-    pub(crate) fn new(cookie_header: String) -> Result<Self, MintError> {
+    pub(crate) fn new(cookie_header: String, graphql_endpoint: &Url) -> Result<Self, PenTestError> {
         let cookie = HeaderValue::from_str(&cookie_header)
-            .map_err(|source| MintError::InvalidCookieHeader { source })?;
-        Ok(Self { cookie })
+            .map_err(|source| PenTestError::InvalidCookieHeader { source })?;
+        Ok(Self {
+            cookie,
+            graphql_endpoint: graphql_endpoint.as_str().to_string(),
+        })
     }
 }
 
@@ -223,7 +226,7 @@ impl Middleware for GraphqlHeaders {
         mut request: Request<SendBody<'_>>,
         next: MiddlewareNext<'_>,
     ) -> Result<Response<Body>, ureq::Error> {
-        if request.uri() == GRAPHQL_ENDPOINT {
+        if request.uri() == self.graphql_endpoint.as_str() {
             request
                 .headers_mut()
                 .insert(ORIGIN, HeaderValue::from_static(GRAPHQL_ORIGIN));
@@ -233,8 +236,8 @@ impl Middleware for GraphqlHeaders {
     }
 }
 
-pub(crate) fn build_cookie_header(raw_cookie_file: &str) -> Result<String, MintError> {
-    let raw = fs::read_to_string(raw_cookie_file).map_err(|source| MintError::FileRead {
+pub(crate) fn build_cookie_header(raw_cookie_file: &str) -> Result<String, PenTestError> {
+    let raw = fs::read_to_string(raw_cookie_file).map_err(|source| PenTestError::FileRead {
         kind: "session cookie",
         path: PathBuf::from(raw_cookie_file),
         source,
@@ -243,7 +246,7 @@ pub(crate) fn build_cookie_header(raw_cookie_file: &str) -> Result<String, MintE
 
     match cookie_expiry(raw)? {
         CookieExpiry::Expired(seconds_ago) => {
-            return Err(MintError::CookieExpired { seconds_ago });
+            return Err(PenTestError::CookieExpired { seconds_ago });
         }
         CookieExpiry::Valid(seconds_remaining) => info!(
             expires_in = %format_duration(seconds_remaining),
@@ -299,7 +302,7 @@ fn format_duration(seconds: i64) -> String {
     }
 }
 
-fn cookie_expiry(raw_cookie: &str) -> Result<CookieExpiry, MintError> {
+fn cookie_expiry(raw_cookie: &str) -> Result<CookieExpiry, PenTestError> {
     let token = raw_cookie
         .split(';')
         .find_map(|pair| {
@@ -311,10 +314,10 @@ fn cookie_expiry(raw_cookie: &str) -> Result<CookieExpiry, MintError> {
             let token = raw_cookie.trim();
             (!token.contains('=') && token.split('.').count() == 3).then_some(token)
         })
-        .ok_or(MintError::MissingSessionCookie)?;
+        .ok_or(PenTestError::MissingSessionCookie)?;
     let exp = decode_jwt_payload(token)
         .and_then(|payload| payload.get("exp")?.as_i64())
-        .ok_or(MintError::InvalidSessionCookie)?;
+        .ok_or(PenTestError::InvalidSessionCookie)?;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
@@ -326,48 +329,47 @@ fn cookie_expiry(raw_cookie: &str) -> Result<CookieExpiry, MintError> {
     }
 }
 
-pub(crate) fn fetch_cloud_id(agent: &ureq::Agent, site: &Url) -> Result<String, MintError> {
+pub(crate) fn fetch_cloud_id(agent: &ureq::Agent, site: &Url) -> Result<String, PenTestError> {
     let mut url = site.clone();
     url.set_path("/_edge/tenant_info");
     let mut response =
         agent
             .get(url.as_str())
             .call()
-            .map_err(|source| MintError::TenantInfoRequest {
+            .map_err(|source| PenTestError::TenantInfoRequest {
                 url: url.clone(),
                 source: Box::new(source),
             })?;
     let status = response.status().as_u16();
-    let body =
-        response
-            .body_mut()
-            .read_to_string()
-            .map_err(|source| MintError::TenantInfoResponse {
-                url: url.clone(),
-                source: Box::new(source),
-            })?;
+    let body = response.body_mut().read_to_string().map_err(|source| {
+        PenTestError::TenantInfoResponse {
+            url: url.clone(),
+            source: Box::new(source),
+        }
+    })?;
     if status >= 400 {
-        return Err(MintError::TenantInfoStatus { url, status, body });
+        return Err(PenTestError::TenantInfoStatus { url, status, body });
     }
 
     let info: TenantInfo = serde_json::from_str(&body)
-        .map_err(|source| MintError::TenantInfoInvalidJson { url, body, source })?;
+        .map_err(|source| PenTestError::TenantInfoInvalidJson { url, body, source })?;
     Ok(info.cloud_id)
 }
 
 pub(crate) fn post_graphql<V, T>(
     agent: &ureq::Agent,
+    graphql_endpoint: &Url,
     request: &GraphqlRequest<V>,
-) -> Result<T, MintError>
+) -> Result<T, PenTestError>
 where
     V: Serialize,
     T: DeserializeOwned,
 {
     let operation_name = request.operation_name.clone();
     let mut response = agent
-        .post(GRAPHQL_ENDPOINT)
+        .post(graphql_endpoint.as_str())
         .send_json(request)
-        .map_err(|source| MintError::GraphqlRequest {
+        .map_err(|source| PenTestError::GraphqlRequest {
             operation_name: operation_name.clone(),
             source: Box::new(source),
         })?;
@@ -376,12 +378,12 @@ where
         response
             .body_mut()
             .read_to_string()
-            .map_err(|source| MintError::GraphqlResponse {
+            .map_err(|source| PenTestError::GraphqlResponse {
                 operation_name: operation_name.clone(),
                 source: Box::new(source),
             })?;
     if status >= 400 {
-        return Err(MintError::GraphqlHttpStatus {
+        return Err(PenTestError::GraphqlHttpStatus {
             operation_name,
             status,
             body,
@@ -390,7 +392,7 @@ where
 
     let response: serde_json::Value = serde_json::from_str(&body).map_err(|source| {
         warn!(%operation_name, response_body = %body, "GraphQL response was not valid JSON");
-        MintError::GraphqlInvalidJson {
+        PenTestError::GraphqlInvalidJson {
             operation_name: operation_name.clone(),
             body: body.clone(),
             source,
@@ -399,14 +401,14 @@ where
     if let Some(errors) = response.get("errors").filter(|errors| !errors.is_null()) {
         let errors: Vec<GraphqlErrorObject> =
             serde_json::from_value(errors.clone()).map_err(|source| {
-                MintError::GraphqlInvalidJson {
+                PenTestError::GraphqlInvalidJson {
                     operation_name: operation_name.clone(),
                     body: body.clone(),
                     source,
                 }
             })?;
         if !errors.is_empty() {
-            return Err(MintError::GraphqlRejected {
+            return Err(PenTestError::GraphqlRejected {
                 operation_name,
                 errors,
             });
@@ -414,7 +416,7 @@ where
     }
 
     let response: GraphqlData<T> =
-        serde_json::from_value(response).map_err(|source| MintError::GraphqlInvalidJson {
+        serde_json::from_value(response).map_err(|source| PenTestError::GraphqlInvalidJson {
             operation_name,
             body,
             source,
@@ -435,12 +437,13 @@ mod tests {
             request: Request<SendBody<'_>>,
             _next: MiddlewareNext<'_>,
         ) -> Result<Response<Body>, ureq::Error> {
-            let (response_body, has_graphql_headers) = if request.uri() == GRAPHQL_ENDPOINT {
-                (r#"{"data":{"value":1}}"#, true)
-            } else {
-                assert_eq!(request.uri(), "https://foo.jira-dev.com/_edge/tenant_info");
-                (r#"{"cloudId":"cloud-1"}"#, false)
-            };
+            let (response_body, has_graphql_headers) =
+                if request.uri() == "https://foo.jira-dev.com/gateway/api/graphql" {
+                    (r#"{"data":{"value":1}}"#, true)
+                } else {
+                    assert_eq!(request.uri(), "https://foo.jira-dev.com/_edge/tenant_info");
+                    (r#"{"cloudId":"cloud-1"}"#, false)
+                };
             let cookie = request
                 .headers()
                 .get(COOKIE)
@@ -490,20 +493,30 @@ mod tests {
         }
     }
 
+    fn test_site() -> Url {
+        Url::parse("https://foo.jira-dev.com").unwrap()
+    }
+
+    fn test_graphql_endpoint() -> Url {
+        let mut endpoint = test_site();
+        endpoint.set_path("/gateway/api/graphql");
+        endpoint
+    }
+
     #[test]
     fn graphql_headers_are_only_sent_to_the_https_graphql_endpoint() {
+        let graphql_endpoint = test_graphql_endpoint();
         let agent: ureq::Agent = ureq::Agent::config_builder()
             .http_status_as_error(false)
-            .middleware(GraphqlHeaders::new("tenant.session.token=test".into()).unwrap())
+            .middleware(
+                GraphqlHeaders::new("tenant.session.token=test".into(), &graphql_endpoint).unwrap(),
+            )
             .middleware(HeaderAssertions)
             .build()
             .into();
 
-        assert_eq!(
-            fetch_cloud_id(&agent, &Url::parse("https://foo.jira-dev.com").unwrap()).unwrap(),
-            "cloud-1"
-        );
-        let data: serde_json::Value = post_graphql(&agent, &request()).unwrap();
+        assert_eq!(fetch_cloud_id(&agent, &test_site()).unwrap(), "cloud-1");
+        let data: serde_json::Value = post_graphql(&agent, &graphql_endpoint, &request()).unwrap();
         assert_eq!(data, json!({ "value": 1 }));
     }
 
@@ -516,6 +529,7 @@ mod tests {
 
         let data: Data = post_graphql(
             &response_agent(200, r#"{"data":{"value":7},"errors":null}"#),
+            &test_graphql_endpoint(),
             &request(),
         )
         .unwrap();
@@ -529,11 +543,12 @@ mod tests {
                 200,
                 r#"{"errors":[{"message":"denied"},{"message":null},{}]}"#,
             ),
+            &test_graphql_endpoint(),
             &request(),
         )
         .unwrap_err();
 
-        let MintError::GraphqlRejected { errors, .. } = error else {
+        let PenTestError::GraphqlRejected { errors, .. } = error else {
             panic!("unexpected error variant")
         };
         assert_eq!(errors.len(), 3);
@@ -544,7 +559,7 @@ mod tests {
 
     #[test]
     fn graphql_error_display_uses_structured_fields() {
-        let error = MintError::GraphqlRejected {
+        let error = PenTestError::GraphqlRejected {
             operation_name: "MutationUnderTest".into(),
             errors: vec![GraphqlErrorObject {
                 message: Some("denied".into()),
@@ -566,20 +581,27 @@ mod tests {
 
         for body in [r#"{"errors":[]}"#, r#"{"data":{}}"#, r#"{"data":null}"#] {
             assert!(matches!(
-                post_graphql::<_, Data>(&response_agent(200, body), &request()),
-                Err(MintError::GraphqlInvalidJson { .. })
+                post_graphql::<_, Data>(
+                    &response_agent(200, body),
+                    &test_graphql_endpoint(),
+                    &request()
+                ),
+                Err(PenTestError::GraphqlInvalidJson { .. })
             ));
         }
     }
 
     #[test]
     fn graphql_http_errors_retain_status() {
-        let error =
-            post_graphql::<_, serde_json::Value>(&response_agent(503, "unavailable"), &request())
-                .unwrap_err();
+        let error = post_graphql::<_, serde_json::Value>(
+            &response_agent(503, "unavailable"),
+            &test_graphql_endpoint(),
+            &request(),
+        )
+        .unwrap_err();
         assert!(matches!(
             error,
-            MintError::GraphqlHttpStatus {
+            PenTestError::GraphqlHttpStatus {
                 status: 503,
                 body,
                 ..

--- a/crates/fsrt/src/commands/invoke_extension.rs
+++ b/crates/fsrt/src/commands/invoke_extension.rs
@@ -12,29 +12,25 @@ const REDACTED_FCT: &str = "<FCT selected at runtime>";
 /// `invoke-extension` arguments.
 #[derive(Args, Debug)]
 pub(crate) struct InvokeExtensionArgs {
-    /// Deployed module key containing the resolver.
-    #[arg(name = "MODULE_KEY")]
-    module_key: String,
-
-    /// Resolver function key to invoke.
+    /// Resolver function key passed to the backend unchanged.
     #[arg(name = "FUNCTION")]
     function: String,
 
-    /// Invocation payload as JSON.
-    #[arg(name = "PAYLOAD")]
-    payload: String,
+    /// Deployed resolver module key.
+    #[arg(name = "MODULE_KEY")]
+    module_key: String,
 
-    /// Replace the default invocation context with this JSON object.
+    /// Optional invocation payload as JSON.
+    #[arg(long, value_name = "JSON", value_parser = parse_payload)]
+    payload: Option<JsonValue>,
+
+    /// Invocation context as JSON (defaults to {}).
     #[arg(long, value_name = "JSON", value_parser = parse_ctx)]
     ctx: Option<JsonValue>,
 
-    /// Reuse this FCT instead of minting one.
+    /// Existing FCT to use instead of minting one.
     #[arg(long)]
     fct: Option<String>,
-
-    /// Invoke asynchronously when supported.
-    #[arg(long = "async", default_value_t = false)]
-    invoke_async: bool,
 
     /// Forge app directory.
     #[arg(long, default_value = ".", value_hint = ValueHint::DirPath)]
@@ -56,46 +52,37 @@ impl InvokeExtensionArgs {
 }
 
 pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
-    let module_key = require_non_empty("MODULE_KEY", &args.module_key)?;
-    let function = require_non_empty("FUNCTION", &args.function)?;
-    if args.fct.as_deref().is_some_and(|fct| fct.trim().is_empty()) {
-        return Err(forge_pen_test::MintError::EmptySuppliedFct.into());
-    }
-    let payload: JsonValue = serde_json::from_str(&args.payload).map_err(|error| {
-        forge_pen_test::MintError::InvocationFailed(format!("PAYLOAD is not valid JSON: {error}"))
-    })?;
-
     let manifest_path = find_manifest_path(&args.app_dir)?;
     let manifest_text = fs::read_to_string(manifest_path)?;
     let manifest: forge_loader::manifest::ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
+    let module_key = args.module_key.as_str();
 
     let config = forge_pen_test::FsrtRemoteConfig::from_path(&args.config)?;
     let tester = forge_pen_test::ForgePenTester::new(&manifest, config)?;
-    let ctx = match &args.ctx {
-        Some(ctx) => ctx.clone(),
-        None => tester.default_invoke_context(module_key)?,
-    };
+    let ctx = args.ctx.clone().unwrap_or_else(|| serde_json::json!({}));
 
     if args.dry_run {
         let request = tester.invoke_extension_request(
             module_key,
-            function,
-            &payload,
+            &args.function,
+            args.payload.as_ref(),
             &ctx,
             REDACTED_FCT,
-            args.invoke_async,
         )?;
         println!("{}", serde_json::to_string_pretty(&request.variables)?);
         return Ok(());
     }
 
+    let context_token = match args.fct.as_deref() {
+        Some(fct) => fct.to_string(),
+        None => tester.mint_fct(module_key, &ctx)?,
+    };
     let outcome = tester.invoke_extension(
         module_key,
-        function,
-        &payload,
+        &args.function,
+        args.payload.as_ref(),
         &ctx,
-        args.fct.as_deref(),
-        args.invoke_async,
+        &context_token,
     )?;
     match outcome.response() {
         Some(response) => println!("{}", serde_json::to_string_pretty(response)?),
@@ -105,149 +92,6 @@ pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
     Ok(())
 }
 
-fn require_non_empty<'a>(name: &str, value: &'a str) -> Result<&'a str> {
-    let value = value.trim();
-    if value.is_empty() {
-        Err(forge_pen_test::MintError::InvocationFailed(format!("{name} must not be empty")).into())
-    } else {
-        Ok(value)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use clap::{CommandFactory, Parser, error::ErrorKind};
-
-    use super::*;
-    use crate::{Args as RootArgs, commands::Command};
-
-    fn args(module_key: &str, function: &str, payload: &str) -> InvokeExtensionArgs {
-        InvokeExtensionArgs {
-            module_key: module_key.to_string(),
-            function: function.to_string(),
-            payload: payload.to_string(),
-            ctx: None,
-            fct: None,
-            invoke_async: false,
-            app_dir: PathBuf::from("unused"),
-            config: PathBuf::from("unused"),
-            dry_run: false,
-        }
-    }
-
-    #[test]
-    fn parses_required_positionals_and_ctx() {
-        let parsed = RootArgs::try_parse_from([
-            "fsrt",
-            "invoke-extension",
-            "module-key",
-            "resolver-fn",
-            r#"{"probe":true}"#,
-            "--ctx",
-            r#"{"issueKey":"TEST-1"}"#,
-            "--async",
-            "--dry-run",
-        ])
-        .unwrap();
-
-        let Some(Command::InvokeExtension(args)) = parsed.command else {
-            panic!("invoke-extension command was not parsed")
-        };
-        assert_eq!(args.module_key, "module-key");
-        assert_eq!(args.function, "resolver-fn");
-        assert_eq!(args.payload, r#"{"probe":true}"#);
-        assert_eq!(args.ctx, Some(serde_json::json!({ "issueKey": "TEST-1" })));
-        assert!(args.invoke_async);
-        assert!(args.diagnostic_logging_requested());
-    }
-
-    #[test]
-    fn requires_all_positional_arguments() {
-        for argv in [
-            vec!["fsrt", "invoke-extension"],
-            vec!["fsrt", "invoke-extension", "module-key"],
-            vec!["fsrt", "invoke-extension", "module-key", "resolver-fn"],
-        ] {
-            assert_eq!(
-                RootArgs::try_parse_from(argv).unwrap_err().kind(),
-                ErrorKind::MissingRequiredArgument
-            );
-        }
-    }
-
-    #[test]
-    fn ctx_must_be_a_json_object_and_context_is_not_an_alias() {
-        for ctx in ["not-json", "[]", "null"] {
-            assert_eq!(
-                RootArgs::try_parse_from([
-                    "fsrt",
-                    "invoke-extension",
-                    "module-key",
-                    "resolver-fn",
-                    "{}",
-                    "--ctx",
-                    ctx,
-                ])
-                .unwrap_err()
-                .kind(),
-                ErrorKind::ValueValidation
-            );
-        }
-
-        assert_eq!(
-            RootArgs::try_parse_from([
-                "fsrt",
-                "invoke-extension",
-                "module-key",
-                "resolver-fn",
-                "{}",
-                "--context",
-                "{}",
-            ])
-            .unwrap_err()
-            .kind(),
-            ErrorKind::UnknownArgument
-        );
-    }
-
-    #[test]
-    fn rejects_empty_values_and_invalid_payload_before_file_access() {
-        for (args, expected) in [
-            (
-                args(" ", "resolver-fn", "{}"),
-                "MODULE_KEY must not be empty",
-            ),
-            (args("module-key", " ", "{}"), "FUNCTION must not be empty"),
-            (
-                args("module-key", "resolver-fn", "not-json"),
-                "PAYLOAD is not valid JSON",
-            ),
-        ] {
-            let error = run(&args).unwrap_err();
-            assert!(error.to_string().contains(expected), "{error}");
-        }
-
-        let mut empty_fct = args("module-key", "resolver-fn", "{}");
-        empty_fct.fct = Some(" ".to_string());
-        assert!(
-            run(&empty_fct)
-                .unwrap_err()
-                .to_string()
-                .contains("supplied FCT must not be empty")
-        );
-    }
-
-    #[test]
-    fn help_documents_the_positional_interface_and_ctx() {
-        let mut command = RootArgs::command();
-        let help = command
-            .find_subcommand_mut("invoke-extension")
-            .expect("invoke-extension subcommand should exist")
-            .render_long_help()
-            .to_string();
-
-        assert!(help.contains("<MODULE_KEY> <FUNCTION> <PAYLOAD>"));
-        assert!(help.contains("--ctx <JSON>"));
-        assert!(!help.contains("--context"));
-    }
+fn parse_payload(value: &str) -> std::result::Result<JsonValue, String> {
+    serde_json::from_str(value).map_err(|error| format!("invalid JSON: {error}"))
 }

--- a/crates/fsrt/src/commands/invoke_extension.rs
+++ b/crates/fsrt/src/commands/invoke_extension.rs
@@ -2,6 +2,7 @@ use std::{fs, path::PathBuf};
 
 use clap::{Args, ValueHint};
 use serde_json::Value as JsonValue;
+use tracing::info;
 
 use crate::{Result, forge_project::find_manifest_path};
 
@@ -12,7 +13,7 @@ const REDACTED_FCT: &str = "<FCT selected at runtime>";
 /// `invoke-extension` arguments.
 #[derive(Args, Debug)]
 pub(crate) struct InvokeExtensionArgs {
-    /// Resolver function key passed to the backend unchanged.
+    /// Resolver function key, optionally prefixed with `resolver.`.
     #[arg(name = "FUNCTION")]
     function: String,
 
@@ -73,10 +74,12 @@ pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
         return Ok(());
     }
 
-    let context_token = match args.fct.as_deref() {
-        Some(fct) => fct.to_string(),
-        None => tester.mint_fct(module_key, &ctx)?,
+    let (context_token, fct_source) = match args.fct.as_deref() {
+        Some(fct) => (fct.to_string(), "supplied"),
+        None => (tester.mint_fct(module_key, &ctx)?, "minted"),
     };
+    info!(fct_source, "selected FCT for extension invocation");
+
     let outcome = tester.invoke_extension(
         module_key,
         &args.function,

--- a/crates/fsrt/src/commands/invoke_extension.rs
+++ b/crates/fsrt/src/commands/invoke_extension.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::{Result, forge_project::find_manifest_path};
 
-use super::parse_ctx;
+use super::parse_json;
 
 const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
@@ -21,12 +21,12 @@ pub(crate) struct InvokeExtensionArgs {
     #[arg(name = "MODULE_KEY")]
     module_key: String,
 
-    /// Optional invocation payload as JSON.
-    #[arg(long, value_name = "JSON", value_parser = parse_payload)]
+    /// Optional invocation payload as a JSON object.
+    #[arg(long, value_name = "JSON", value_parser = parse_json)]
     payload: Option<JsonValue>,
 
-    /// Invocation context as JSON (defaults to {}).
-    #[arg(long, value_name = "JSON", value_parser = parse_ctx)]
+    /// Invocation context as a JSON object (defaults to {}).
+    #[arg(long, value_name = "JSON", value_parser = parse_json)]
     ctx: Option<JsonValue>,
 
     /// Existing FCT to use instead of minting one.
@@ -93,8 +93,4 @@ pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn parse_payload(value: &str) -> std::result::Result<JsonValue, String> {
-    serde_json::from_str(value).map_err(|error| format!("invalid JSON: {error}"))
 }

--- a/crates/fsrt/src/commands/mint_fct.rs
+++ b/crates/fsrt/src/commands/mint_fct.rs
@@ -5,7 +5,7 @@ use tracing::info;
 
 use crate::{Result, forge_project::find_manifest_path};
 
-use super::parse_ctx;
+use super::parse_json;
 
 /// `mint-fct` arguments.
 #[derive(Args, Debug)]
@@ -23,7 +23,7 @@ pub(crate) struct MintFctArgs {
     config: PathBuf,
 
     /// JSON object to include in the extension context.
-    #[arg(long, value_name = "JSON", value_parser = parse_ctx)]
+    #[arg(long, value_name = "JSON", value_parser = parse_json)]
     ctx: Option<serde_json::Value>,
 
     /// Query metadata and print the GraphQL request without minting.

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::{Result, forge_project::find_manifest_path};
 
-use super::parse_ctx;
+use super::parse_json;
 
 const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
@@ -28,7 +28,7 @@ pub(crate) struct MintFitArgs {
     /// Force a new FCT with this inline JSON object as its context.
     #[arg(
         long = "ctx",
-        value_parser = parse_ctx,
+        value_parser = parse_json,
         requires = "module_key",
         conflicts_with = "fct"
     )]

--- a/crates/fsrt/src/commands/mod.rs
+++ b/crates/fsrt/src/commands/mod.rs
@@ -6,15 +6,15 @@ pub(crate) mod invoke_extension;
 pub(crate) mod mint_fct;
 pub(crate) mod mint_fit;
 
-fn parse_ctx(value: &str) -> std::result::Result<serde_json::Value, String> {
-    let ctx: serde_json::Value =
+fn parse_json(value: &str) -> std::result::Result<serde_json::Value, String> {
+    let json: serde_json::Value =
         serde_json::from_str(value).map_err(|error| format!("invalid JSON: {error}"))?;
 
-    if !ctx.is_object() {
-        return Err("ctx must be a JSON object".to_string());
+    if !json.is_object() {
+        return Err("must be a JSON object".to_string());
     }
 
-    Ok(ctx)
+    Ok(json)
 }
 
 /// CLI subcommands.

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -64,7 +64,7 @@ pub struct Args {
     debug: bool,
 
     /// Print diagnostics to stderr. A valid `FORGE_LOG` filter takes precedence.
-    #[arg(long, global = true, default_value_t = false)]
+    #[arg(long, global = true, default_value_t = false, display_order = 100)]
     verbose: bool,
 
     /// Dump the IR for the specified function

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -871,6 +871,11 @@ fn main() -> Result<()> {
     if let Some(command) = &args.command {
         if let Err(err) = command.run() {
             eprintln!("error: {err}");
+            let mut source = err.source();
+            while let Some(cause) = source {
+                eprintln!("  caused by: {cause}");
+                source = cause.source();
+            }
             std::process::exit(1);
         }
         return Ok(());


### PR DESCRIPTION
## Summary

- Simplify `invoke-extension` to use `<FUNCTION> <MODULE_KEY>` with optional `--payload`, `--ctx`, and `--fct`.
- Default context to `{}` and omit the payload field when none is provided.
- Mint an FCT automatically or use one supplied through `--fct`.
- Accept function keys with an optional `resolver.` prefix.
- Remove `--async` and deployment-derived default contexts.
- Derive the GraphQL endpoint from the configured site.
- Rename `MintError` to `PenTestError` and share JSON-object parsing across commands.