### PR TITLE
Invoke extension additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,6 @@ name = "forge_pen_test"
 version = "0.1.0"
 dependencies = [
  "base64",
- "forge_loader",
  "serde",
  "serde_json",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Arguments:
   [DIRS]...  The directory to scan. Assumes there is a `manifest.yaml` file in the top level directory, and that the source code is located in `src/`
 
 Commands:
-  invoke-extension  Invoke a resolver-backed extension with a tester-controlled payload
-  mint-fct          Mint an FCT for a deployed module
-  mint-fit          Mint an FIT for a deployed module and Forge remote
+  dast  Run pentesting commands
 
   Options:
     -d, --debug
@@ -34,7 +32,7 @@ Commands:
     --graphql-schema-path <LOCATION>        Uses the graphql schema in location; othwerwise selects ~/.config dir
 ```
 
-Run `fsrt --help` or `fsrt <COMMAND> --help` for current options.
+Run `fsrt --help`, `fsrt dast --help`, or `fsrt dast <COMMAND> --help` for current options.
 
 ## Installation
 
@@ -65,9 +63,9 @@ cargo install --git https://github.com/atlassian-labs/FSRT --locked
 ## Commands
 
 ```text
-fsrt mint-fct <MODULE_KEY> [OPTIONS]
-fsrt mint-fit <REMOTE_KEY> (--module <MODULE_KEY> | --fct <FCT>) [OPTIONS]
-fsrt invoke-extension <FUNCTION> <MODULE_KEY> [--fct <FCT>] [OPTIONS]
+fsrt dast mint-fct <MODULE_KEY> [OPTIONS]
+fsrt dast mint-fit <REMOTE_KEY> (--module <MODULE_KEY> | --fct <FCT>) [OPTIONS]
+fsrt dast invoke-extension <FUNCTION> <MODULE_KEY> [--fct <FCT>] [OPTIONS]
 ```
 
 All three commands accept either `--app-id <APP_ID>` to identify the app directly or
@@ -95,7 +93,7 @@ the request's context token.
 By default, live mint commands print only the token, while `invoke-extension` prints the
 backend response. `--dry-run` queries metadata without signing tokens or invoking the
 extension and prints redacted request variables. `--verbose` prints live diagnostics to
-stderr. Run `fsrt <COMMAND> --help` for all options.
+stderr. Run `fsrt dast <COMMAND> --help` for all options.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cargo install --git https://github.com/atlassian-labs/FSRT --locked
 ```text
 fsrt dast mint-fct <MODULE_KEY> [OPTIONS]
 fsrt dast mint-fit <REMOTE_KEY> (--module <MODULE_KEY> | --fct <FCT>) [OPTIONS]
-fsrt dast invoke-extension <FUNCTION> <MODULE_KEY> [--fct <FCT>] [OPTIONS]
+fsrt dast invoke-extension [FUNCTION] <MODULE_KEY> [--entrypoint <ENTRYPOINT>] [--fct <FCT>] [OPTIONS]
 ```
 
 All three commands accept either `--app-id <APP_ID>` to identify the app directly or
@@ -82,13 +82,12 @@ selected extension's `context` object.
 | Use an existing FCT | `<REMOTE_KEY> --fct <FCT>` | Uses the supplied FCT when `--module` and `--ctx` are omitted. |
 | Mint a new FCT | `<REMOTE_KEY> --module <MODULE_KEY>` | Mints an FCT with an empty context, then uses it to mint the FIT. Add `--ctx '<JSON>'` to set its context. |
 
-`invoke-extension` always resolves its request target from `<MODULE_KEY>`. The FCT only supplies
-the request's context token.
+`invoke-extension` calls a deployed Forge module directly, which is useful for testing its behavior
+with custom payloads without going through the product UI. Pass a module key and, when needed, a
+resolver function or `--entrypoint`; omitting `--entrypoint` leaves selection to the backend.
 
-| Mode | Required inputs | Behavior |
-| --- | --- | --- |
-| Use an existing FCT | `<FUNCTION> <MODULE_KEY> --fct <FCT>` | Builds the request from the selected deployed module and uses the supplied FCT only as its context token. |
-| Mint a new FCT | `<FUNCTION> <MODULE_KEY>` | Calls `mint_fct` for the selected module, then invokes it. Add `--ctx '<JSON>'` to use that context for both operations. |
+The command mints an FCT automatically unless one is supplied with `--fct`. Use `--ctx` to provide
+invocation context.
 
 By default, live mint commands print only the token, while `invoke-extension` prints the
 backend response. `--dry-run` queries metadata without signing tokens or invoking the

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ fsrt mint-fit <REMOTE_KEY> (--module <MODULE_KEY> | --fct <FCT>) [OPTIONS]
 fsrt invoke-extension <FUNCTION> <MODULE_KEY> [--fct <FCT>] [OPTIONS]
 ```
 
-All three commands use `--app-dir` and a TOML configuration file; see
-[`fsrt-remote.toml.example`](fsrt-remote.toml.example). Keep that configuration and its
-cookie file untracked.
+All three commands accept either `--app-id <APP_ID>` to identify the app directly or
+`--app-dir <DIR>` to read the app ID from its manifest. They also use a TOML
+configuration file; see [`fsrt-remote.toml.example`](fsrt-remote.toml.example).
 
 `mint-fct` mints an FCT for a deployed module. Pass `--ctx '<JSON>'` to populate the
 selected extension's `context` object.

--- a/crates/forge_pen_test/Cargo.toml
+++ b/crates/forge_pen_test/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-forge_loader.workspace = true
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/forge_pen_test/src/app_config.rs
+++ b/crates/forge_pen_test/src/app_config.rs
@@ -66,7 +66,6 @@ impl AppConfig {
             .extensions
             .iter()
             .filter(|extension| extension.extension_type == "core:remote")
-            .filter(|extension| !extension.module_key.is_empty())
             .map(|extension| extension.module_key.clone())
             .collect::<Vec<_>>();
         remote_keys.sort(); // why need to sort and dedup?
@@ -161,17 +160,6 @@ mod tests {
                 .is_err()
         );
     }
-
-    #[test]
-    fn missing_module_key_reports_the_actual_extension_list() {
-        assert!(matches!(
-            config(vec![extension("none", "extension-1")])
-                .extension_for_module_key("missing"),
-            Err(PenTestError::ModuleKeyNotFound { module_key, available })
-                if module_key == "missing" && available == ["none"]
-        ));
-    }
-
     #[test]
     fn duplicate_module_keys_return_the_first_extension() {
         let config = config(vec![
@@ -189,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_keys_only_include_unique_nonempty_core_remote_extensions() {
+    fn remote_keys_include_unique_core_remote_extensions() {
         let config = config(vec![
             extension_with_type("remote-b", "extension-1", "core:remote"),
             extension_with_type("panel", "extension-2", "jira:issuePanel"),
@@ -200,7 +188,11 @@ mod tests {
 
         assert_eq!(
             config.remote_keys(),
-            vec!["remote-a".to_string(), "remote-b".to_string()]
+            vec![
+                "".to_string(),
+                "remote-a".to_string(),
+                "remote-b".to_string()
+            ]
         );
     }
 }

--- a/crates/forge_pen_test/src/fct.rs
+++ b/crates/forge_pen_test/src/fct.rs
@@ -1,0 +1,104 @@
+//! Forge Context Token request construction and minting.
+
+use serde::Deserialize;
+use tracing::{debug, info};
+
+use crate::{ForgePenTester, GraphqlErrorObject, GraphqlRequest, PenTestError};
+
+const FCT_MUTATION: &str = r#"mutation SignForgeContextToken($input: GlobalAppSignForgeContextTokensInput!) {
+  globalApp_signForgeContextTokens(input: $input) {
+    success
+    errors {
+      message
+    }
+    tokens {
+      jwt
+    }
+  }
+}"#;
+
+const FCT_OPERATION_NAME: &str = "SignForgeContextToken";
+
+#[derive(Debug, Deserialize)]
+struct FctData {
+    #[serde(rename = "globalApp_signForgeContextTokens")]
+    result: FctResult,
+}
+
+#[derive(Debug, Deserialize)]
+struct FctResult {
+    success: bool,
+    errors: Vec<GraphqlErrorObject>,
+    tokens: Vec<ForgeContextToken>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgeContextToken {
+    jwt: String,
+}
+
+impl ForgePenTester<'_, '_> {
+    /// Constructs the exact GraphQL request that `mint_fct` will send.
+    pub fn mint_fct_request(
+        &self,
+        module_key: &str,
+        ctx: &serde_json::Value,
+    ) -> Result<GraphqlRequest<serde_json::Value>, PenTestError> {
+        if !ctx.is_object() {
+            return Err(PenTestError::InvalidFctContext);
+        }
+        let extension = self.config().extension_for_module_key(module_key)?;
+        info!(
+            module_key = ?module_key,
+            deployment_id = ?extension.deployment_id(),
+            extension_id = ?extension.extension_id(),
+            extension_type = ?extension.extension_type(),
+            "selected deployed extension"
+        );
+        Ok(GraphqlRequest {
+            operation_name: FCT_OPERATION_NAME.to_string(),
+            query: FCT_MUTATION.to_string(),
+            variables: serde_json::json!({
+                "input": {
+                    "contextIds": [self.config().context_id()],
+                    "extensionContexts": [{
+                        "appVersion": self.config().app_version(),
+                        "context": ctx,
+                        "extensionId": extension.extension_id(),
+                        "extensionType": extension.extension_type(),
+                        "installationId": self.config().installation_id()
+                    }]
+                }
+            }),
+        })
+    }
+
+    /// Mints a new FCT and replaces the cache only on success.
+    pub fn mint_fct(
+        &self,
+        module_key: &str,
+        ctx: &serde_json::Value,
+    ) -> Result<String, PenTestError> {
+        let request = self.mint_fct_request(module_key, ctx)?;
+        let variables = format!("{:#}", request.variables);
+        info!(variables = %variables, "FCT GraphQL variables");
+        let data: FctData = self.post_graphql_mutation(&request)?;
+        let FctResult {
+            success,
+            errors,
+            tokens,
+        } = data.result;
+        if !success || !errors.is_empty() {
+            return Err(PenTestError::MintRejected { success, errors });
+        }
+
+        let jwt = tokens
+            .into_iter()
+            .next()
+            .map(|token| token.jwt)
+            .ok_or(PenTestError::MissingFctToken)?;
+        self.replace_cached_fct_jwt(&jwt);
+        debug!("successfully minted Forge Context Token");
+        Ok(jwt)
+    }
+}

--- a/crates/forge_pen_test/src/fct.rs
+++ b/crates/forge_pen_test/src/fct.rs
@@ -37,7 +37,7 @@ struct ForgeContextToken {
     jwt: String,
 }
 
-impl ForgePenTester<'_, '_> {
+impl ForgePenTester {
     /// Constructs the exact GraphQL request that `mint_fct` will send.
     pub fn mint_fct_request(
         &self,

--- a/crates/forge_pen_test/src/fit.rs
+++ b/crates/forge_pen_test/src/fit.rs
@@ -33,7 +33,7 @@ struct ForgeInvocationToken {
     jwt: String,
 }
 
-impl ForgePenTester<'_, '_> {
+impl ForgePenTester {
     /// Constructs the exact GraphQL request used to mint a FIT.
     pub fn mint_fit_request(
         &self,

--- a/crates/forge_pen_test/src/fit.rs
+++ b/crates/forge_pen_test/src/fit.rs
@@ -1,0 +1,84 @@
+//! Forge Invocation Token request construction and minting.
+
+use serde::Deserialize;
+use tracing::{debug, info};
+
+use crate::{ForgePenTester, GraphqlRequest, PenTestError};
+
+const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvocationTokenForUIInput!) {
+  signInvocationTokenForUI(input: $input) {
+    forgeInvocationToken {
+      jwt
+    }
+  }
+}"#;
+
+const FIT_OPERATION_NAME: &str = "SignInvocationTokenForUI";
+const REDACTED_FCT: &str = "<FCT selected at runtime>";
+
+#[derive(Debug, Deserialize)]
+struct FitData {
+    #[serde(rename = "signInvocationTokenForUI")]
+    result: Option<FitResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FitResult {
+    #[serde(rename = "forgeInvocationToken")]
+    token: Option<ForgeInvocationToken>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgeInvocationToken {
+    jwt: String,
+}
+
+impl ForgePenTester<'_, '_> {
+    /// Constructs the exact GraphQL request used to mint a FIT.
+    pub fn mint_fit_request(
+        &self,
+        fct: &str,
+        remote_key: &str,
+    ) -> Result<GraphqlRequest<serde_json::Value>, PenTestError> {
+        if fct.trim().is_empty() {
+            return Err(PenTestError::EmptySuppliedFct);
+        }
+
+        Ok(GraphqlRequest {
+            operation_name: FIT_OPERATION_NAME.to_string(),
+            query: FIT_MUTATION.to_string(),
+            variables: serde_json::json!({
+                "input": {
+                    "forgeContextToken": fct,
+                    "remoteKey": remote_key
+                }
+            }),
+        })
+    }
+
+    /// Mints a FIT for a Forge remote using the supplied FCT.
+    pub fn mint_fit(&self, remote_key: &str, fct: &str) -> Result<String, PenTestError> {
+        let request = self.mint_fit_request(fct, remote_key)?;
+        let mut variables = request.variables.clone();
+        variables["input"]["forgeContextToken"] = REDACTED_FCT.into();
+        let variables = format!("{variables:#}");
+        info!(
+            operation_name = FIT_OPERATION_NAME,
+            variables = %variables,
+            "FIT GraphQL variables"
+        );
+        let token = (|| {
+            let data: FitData = self.post_graphql_mutation(&request)?;
+            data.result
+                .and_then(|result| result.token)
+                .map(|token| token.jwt)
+                .ok_or(PenTestError::MissingFitToken)
+        })()
+        .map_err(|source| PenTestError::FitMintFailed {
+            source: Box::new(source),
+            available: self.config().remote_keys(),
+        })?;
+        debug!("successfully minted Forge Invocation Token");
+        Ok(token)
+    }
+}

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -2,7 +2,6 @@
 
 use std::cell::RefCell;
 
-use forge_loader::manifest::ForgeManifest;
 use serde::Deserialize;
 use tracing::{info, warn};
 use ureq::Agent;
@@ -138,21 +137,17 @@ struct DeployedExtension {
 /// Reusable client for Forge penetration-testing operations.
 ///
 /// Reuses authentication, one [`Agent`], and a deployment snapshot.
-pub struct ForgePenTester<'manifest, 'source> {
+pub struct ForgePenTester {
     config: AppConfig,
     agent: Agent,
-    manifest: &'manifest ForgeManifest<'source>,
     site: Url,
     cached_fct_jwt: RefCell<String>,
 }
 
-impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
-    /// Validates configuration and fetches a deployment snapshot.
+impl ForgePenTester {
+    /// Validates configuration for `app_id` and fetches a deployment snapshot.
     /// Reconstruct the client to observe a newer deployment.
-    pub fn new(
-        manifest: &'manifest ForgeManifest<'source>,
-        file_config: FsrtRemoteConfig,
-    ) -> Result<Self, PenTestError> {
+    pub fn new(app_id: &str, file_config: FsrtRemoteConfig) -> Result<Self, PenTestError> {
         let FsrtRemoteConfig {
             site,
             auth,
@@ -162,7 +157,6 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         let environment = environment_key
             .map(EnvironmentSelection::Key)
             .unwrap_or(EnvironmentSelection::Automatic);
-        let app_id = manifest.app.id.to_string();
         let mut graphql_endpoint = site.clone();
         graphql_endpoint.set_path("/gateway/api/graphql");
         let cookie_header = build_cookie_header(&auth.raw_cookie_file)?;
@@ -182,11 +176,11 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
             query: APPS_QUERY.to_string(),
             variables: serde_json::json!({
                 "ctx": &context_id,
-                "appId": &app_id
+                "appId": app_id
             }),
         };
         let data: AppsData = post_graphql(&agent, &graphql_endpoint, &apps_request)?;
-        let config = resolve_app_config(data, &context_id, &app_id, environment)?;
+        let config = resolve_app_config(data, &context_id, app_id, environment)?;
         info!(
             product = ?product,
             app_id = ?app_id,
@@ -198,7 +192,6 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         Ok(Self {
             config,
             agent,
-            manifest,
             site,
             cached_fct_jwt: RefCell::new(String::new()),
         })
@@ -207,11 +200,6 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
     /// Returns the finalized app configuration.
     pub fn config(&self) -> &AppConfig {
         &self.config
-    }
-
-    /// Returns the Forge manifest.
-    pub fn manifest(&self) -> &ForgeManifest<'source> {
-        self.manifest
     }
 
     /// Returns the cached FCT when structurally valid and unexpired.
@@ -378,8 +366,7 @@ mod tests {
         format!("{header}.{payload}.{}", URL_SAFE_NO_PAD.encode("signature"))
     }
 
-    fn tester() -> ForgePenTester<'static, 'static> {
-        let manifest = Box::leak(Box::new(ForgeManifest::default()));
+    fn tester() -> ForgePenTester {
         ForgePenTester {
             config: AppConfig {
                 context_id: CONTEXT_ID.into(),
@@ -394,7 +381,6 @@ mod tests {
                 installation_id: "installation-1".into(),
             },
             agent: Agent::new_with_defaults(),
-            manifest,
             site: Url::parse("https://example.atlassian.net").unwrap(),
             cached_fct_jwt: RefCell::new(String::new()),
         }

--- a/crates/forge_pen_test/src/forge_pentester.rs
+++ b/crates/forge_pen_test/src/forge_pentester.rs
@@ -4,15 +4,15 @@ use std::cell::RefCell;
 
 use forge_loader::manifest::ForgeManifest;
 use serde::Deserialize;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 use ureq::Agent;
 use url::Url;
 
 use crate::app_config::{AppConfig, ExtensionConfig};
 use crate::fsrt_remote_config::FsrtRemoteConfig;
 use crate::mint_common::{
-    GraphqlErrorObject, GraphqlHeaders, GraphqlRequest, JwtValidity, PenTestError,
-    build_cookie_header, decode_jwt_payload, fetch_cloud_id, post_graphql,
+    GraphqlHeaders, GraphqlRequest, JwtValidity, PenTestError, build_cookie_header,
+    decode_jwt_payload, fetch_cloud_id, post_graphql,
 };
 
 const PRODUCTION_ENVIRONMENT_KEY: &str = "production";
@@ -60,28 +60,6 @@ const APPS_QUERY: &str = r#"query Apps(
     }
   }
 }"#;
-
-const DEFAULT_GLOBAL_APP_MUTATION: &str = r#"mutation SignForgeContextToken($input: GlobalAppSignForgeContextTokensInput!) {
-  globalApp_signForgeContextTokens(input: $input) {
-    success
-    errors {
-      message
-    }
-    tokens {
-      jwt
-    }
-  }
-}"#;
-const GLOBAL_APP_OPERATION_NAME: &str = "SignForgeContextToken";
-const FIT_MUTATION: &str = r#"mutation SignInvocationTokenForUI($input: SignInvocationTokenForUIInput!) {
-  signInvocationTokenForUI(input: $input) {
-    forgeInvocationToken {
-      jwt
-    }
-  }
-}"#;
-const FIT_OPERATION_NAME: &str = "SignInvocationTokenForUI";
-const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum EnvironmentSelection {
@@ -157,42 +135,7 @@ struct DeployedExtension {
     extension_type_key: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct FctData {
-    #[serde(rename = "globalApp_signForgeContextTokens")]
-    result: FctResult,
-}
-
-#[derive(Debug, Deserialize)]
-struct FctResult {
-    success: bool,
-    errors: Vec<GraphqlErrorObject>,
-    tokens: Vec<ForgeContextToken>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ForgeContextToken {
-    jwt: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct FitData {
-    #[serde(rename = "signInvocationTokenForUI")]
-    result: Option<FitResult>,
-}
-
-#[derive(Debug, Deserialize)]
-struct FitResult {
-    #[serde(rename = "forgeInvocationToken")]
-    token: Option<ForgeInvocationToken>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ForgeInvocationToken {
-    jwt: String,
-}
-
-/// Reusable client for minting Forge Context and Invocation Tokens.
+/// Reusable client for Forge penetration-testing operations.
 ///
 /// Reuses authentication, one [`Agent`], and a deployment snapshot.
 pub struct ForgePenTester<'manifest, 'source> {
@@ -291,39 +234,10 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         }
     }
 
-    /// Constructs the exact GraphQL request that `mint_fct` will send.
-    pub fn mint_fct_request(
-        &self,
-        module_key: &str,
-        ctx: &serde_json::Value,
-    ) -> Result<GraphqlRequest<serde_json::Value>, PenTestError> {
-        if !ctx.is_object() {
-            return Err(PenTestError::InvalidFctContext);
-        }
-        let extension = self.config.extension_for_module_key(module_key)?;
-        info!(
-            module_key = ?module_key,
-            deployment_id = ?extension.deployment_id(),
-            extension_id = ?extension.extension_id(),
-            extension_type = ?extension.extension_type(),
-            "selected deployed extension"
-        );
-        Ok(GraphqlRequest {
-            operation_name: GLOBAL_APP_OPERATION_NAME.to_string(),
-            query: DEFAULT_GLOBAL_APP_MUTATION.to_string(),
-            variables: serde_json::json!({
-                "input": {
-                    "contextIds": [self.config.context_id()],
-                    "extensionContexts": [{
-                        "appVersion": self.config.app_version(),
-                        "context": ctx,
-                        "extensionId": extension.extension_id(),
-                        "extensionType": extension.extension_type(),
-                        "installationId": self.config.installation_id()
-                    }]
-                }
-            }),
-        })
+    pub(crate) fn replace_cached_fct_jwt(&self, jwt: &str) {
+        let mut cached_fct_jwt = self.cached_fct_jwt.borrow_mut();
+        cached_fct_jwt.clear();
+        cached_fct_jwt.push_str(jwt);
     }
 
     /// Sends a GraphQL mutation and returns its required, generic data object.
@@ -341,83 +255,6 @@ impl<'manifest, 'source> ForgePenTester<'manifest, 'source> {
         let mut graphql_endpoint = self.site.clone();
         graphql_endpoint.set_path("/gateway/api/graphql");
         post_graphql(&self.agent, &graphql_endpoint, request)
-    }
-
-    /// Mints a new FCT and replaces the cache only on success.
-    pub fn mint_fct(
-        &self,
-        module_key: &str,
-        ctx: &serde_json::Value,
-    ) -> Result<String, PenTestError> {
-        let request = self.mint_fct_request(module_key, ctx)?;
-        let variables = format!("{:#}", request.variables);
-        info!(variables = %variables, "FCT GraphQL variables");
-        let data: FctData = self.post_graphql_mutation(&request)?;
-        let FctResult {
-            success,
-            errors,
-            tokens,
-        } = data.result;
-        if !success || !errors.is_empty() {
-            return Err(PenTestError::MintRejected { success, errors });
-        }
-
-        let jwt = tokens
-            .into_iter()
-            .next()
-            .map(|token| token.jwt)
-            .ok_or(PenTestError::MissingFctToken)?;
-        self.cached_fct_jwt.borrow_mut().clone_from(&jwt);
-        debug!("successfully minted Forge Context Token");
-        Ok(jwt)
-    }
-
-    /// Constructs the exact GraphQL request used to mint a FIT.
-    pub fn mint_fit_request(
-        &self,
-        fct: &str,
-        remote_key: &str,
-    ) -> Result<GraphqlRequest<serde_json::Value>, PenTestError> {
-        if fct.trim().is_empty() {
-            return Err(PenTestError::EmptySuppliedFct);
-        }
-
-        Ok(GraphqlRequest {
-            operation_name: FIT_OPERATION_NAME.to_string(),
-            query: FIT_MUTATION.to_string(),
-            variables: serde_json::json!({
-                "input": {
-                    "forgeContextToken": fct,
-                    "remoteKey": remote_key
-                }
-            }),
-        })
-    }
-
-    /// Mints a FIT for a Forge remote using the supplied FCT.
-    pub fn mint_fit(&self, remote_key: &str, fct: &str) -> Result<String, PenTestError> {
-        let request = self.mint_fit_request(fct, remote_key)?;
-        let mut variables = request.variables.clone();
-        variables["input"]["forgeContextToken"] = REDACTED_FCT.into();
-        let variables = format!("{variables:#}");
-        info!(
-            operation_name = FIT_OPERATION_NAME,
-            variables = %variables,
-            "FIT GraphQL variables"
-        );
-        let token = (|| {
-            let data: FitData = self.post_graphql_mutation(&request)?;
-            data.result
-                .and_then(|result| result.token)
-                .map(|token| token.jwt)
-                .ok_or(PenTestError::MissingFitToken)
-        })()
-        .map_err(|source| PenTestError::FitMintFailed {
-            source: Box::new(source),
-            available: self.config.remote_keys(),
-        })?;
-        debug!("successfully minted Forge Invocation Token");
-        Ok(token)
     }
 }
 
@@ -674,8 +511,12 @@ mod tests {
             .mint_fct_request("installation-1-module", &context)
             .unwrap();
 
-        assert_eq!(request.operation_name, GLOBAL_APP_OPERATION_NAME);
-        assert_eq!(request.query, DEFAULT_GLOBAL_APP_MUTATION);
+        assert_eq!(request.operation_name, "SignForgeContextToken");
+        assert!(
+            request
+                .query
+                .contains("globalApp_signForgeContextTokens(input: $input)")
+        );
         assert_eq!(
             request.variables,
             serde_json::json!({
@@ -752,8 +593,12 @@ mod tests {
             .mint_fit_request(" fct ", "not-declared-in-manifest")
             .unwrap();
 
-        assert_eq!(request.operation_name, FIT_OPERATION_NAME);
-        assert_eq!(request.query, FIT_MUTATION);
+        assert_eq!(request.operation_name, "SignInvocationTokenForUI");
+        assert!(
+            request
+                .query
+                .contains("signInvocationTokenForUI(input: $input)")
+        );
         assert_eq!(
             request.variables,
             serde_json::json!({

--- a/crates/forge_pen_test/src/invoke.rs
+++ b/crates/forge_pen_test/src/invoke.rs
@@ -1,4 +1,4 @@
-//! Direct Forge resolver invocation support.
+//! Direct Forge extension invocation support.
 
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
@@ -53,7 +53,8 @@ impl ForgePenTester {
     pub fn invoke_extension_request(
         &self,
         module_key: &str,
-        function_key: &str,
+        entry_point: Option<&str>,
+        function_key: Option<&str>,
         extension_payload: Option<&JsonValue>,
         ctx: &JsonValue,
         context_token: &str,
@@ -62,45 +63,75 @@ impl ForgePenTester {
             return Err(PenTestError::EmptySuppliedFct);
         }
         let extension = self.config().extension_for_module_key(module_key)?;
-        let function_key = function_key
-            .strip_prefix("resolver.")
-            .unwrap_or(function_key);
-        let mut call = serde_json::json!({ "functionKey": function_key });
-        if let Some(extension_payload) = extension_payload {
-            call.as_object_mut()
-                .expect("resolver call must be a JSON object")
-                .insert("payload".to_string(), extension_payload.clone());
+        let function_key = function_key.map(|key| key.strip_prefix("resolver.").unwrap_or(key));
+        if entry_point == Some(RESOLVER_ENTRY_POINT) && function_key.is_none() {
+            return Err(PenTestError::InvocationFailed(
+                "resolver function key must not be empty".to_string(),
+            ));
+        }
+
+        let mut payload = match function_key {
+            Some(function_key) => {
+                let mut call = serde_json::json!({ "functionKey": function_key });
+                if let Some(extension_payload) = extension_payload {
+                    call.as_object_mut()
+                        .expect("resolver call must be a JSON object")
+                        .insert("payload".to_string(), extension_payload.clone());
+                }
+                serde_json::json!({ "call": call })
+            }
+            None => extension_payload
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({})),
+        };
+        let payload_object = payload.as_object_mut().ok_or_else(|| {
+            PenTestError::InvocationFailed(
+                "non-resolver invocation payload must be a JSON object".to_string(),
+            )
+        })?;
+        payload_object.insert("context".to_string(), ctx.clone());
+        payload_object.insert(
+            "contextToken".to_string(),
+            JsonValue::String(context_token.to_string()),
+        );
+
+        let mut input = serde_json::json!({
+            "contextIds": [self.config().context_id()],
+            "extensionId": extension.extension_id(),
+            "payload": payload,
+        });
+        if let Some(entry_point) = entry_point {
+            input
+                .as_object_mut()
+                .expect("invocation input must be a JSON object")
+                .insert(
+                    "entryPoint".to_string(),
+                    JsonValue::String(entry_point.to_string()),
+                );
         }
 
         Ok(GraphqlRequest {
             operation_name: INVOKE_OPERATION_NAME.to_string(),
             query: INVOKE_MUTATION.to_string(),
             variables: serde_json::json!({
-                "input": {
-                    "contextIds": [self.config().context_id()],
-                    "entryPoint": RESOLVER_ENTRY_POINT,
-                    "extensionId": extension.extension_id(),
-                    "payload": {
-                        "call": call,
-                        "context": ctx,
-                        "contextToken": context_token,
-                    }
-                }
+                "input": input
             }),
         })
     }
 
-    /// Invokes a resolver-backed extension with an existing FCT.
+    /// Invokes an extension with an existing FCT.
     pub fn invoke_extension(
         &self,
         module_key: &str,
-        function_key: &str,
+        entry_point: Option<&str>,
+        function_key: Option<&str>,
         extension_payload: Option<&JsonValue>,
         ctx: &JsonValue,
         context_token: &str,
     ) -> Result<InvocationOutcome, PenTestError> {
         let request = self.invoke_extension_request(
             module_key,
+            entry_point,
             function_key,
             extension_payload,
             ctx,

--- a/crates/forge_pen_test/src/invoke.rs
+++ b/crates/forge_pen_test/src/invoke.rs
@@ -48,7 +48,7 @@ impl InvocationOutcome {
     }
 }
 
-impl ForgePenTester<'_, '_> {
+impl ForgePenTester {
     /// Constructs the exact GraphQL request used to invoke a deployed module.
     pub fn invoke_extension_request(
         &self,

--- a/crates/forge_pen_test/src/lib.rs
+++ b/crates/forge_pen_test/src/lib.rs
@@ -1,6 +1,8 @@
 //! Forge pen-testing toolkit.
 
 mod app_config;
+mod fct;
+mod fit;
 mod forge_pentester;
 mod fsrt_remote_config;
 mod invoke;

--- a/crates/forge_pen_test/src/mint_common.rs
+++ b/crates/forge_pen_test/src/mint_common.rs
@@ -1,4 +1,4 @@
-//! Authentication, JWT, HTTP, and GraphQL support for FCT minting.
+//! Shared authentication, JWT, HTTP, and GraphQL support.
 
 use std::{fs, path::PathBuf};
 

--- a/crates/fsrt/src/commands/invoke_extension.rs
+++ b/crates/fsrt/src/commands/invoke_extension.rs
@@ -1,12 +1,12 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::{Args, ValueHint};
 use serde_json::Value as JsonValue;
 use tracing::info;
 
-use crate::{Result, forge_project::find_manifest_path};
+use crate::Result;
 
-use super::parse_json;
+use super::{parse_json, resolve_app_id};
 
 const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
@@ -33,9 +33,13 @@ pub(crate) struct InvokeExtensionArgs {
     #[arg(long)]
     fct: Option<String>,
 
-    /// Forge app directory.
-    #[arg(long, default_value = ".", value_hint = ValueHint::DirPath)]
-    app_dir: PathBuf,
+    /// Forge app ID. Does not require a local manifest.
+    #[arg(long, value_name = "APP_ID", conflicts_with = "app_dir")]
+    app_id: Option<String>,
+
+    /// Forge app directory. Defaults to the current directory when --app-id is omitted.
+    #[arg(long, value_hint = ValueHint::DirPath, conflicts_with = "app_id")]
+    app_dir: Option<PathBuf>,
 
     /// Path to `fsrt-remote.toml`.
     #[arg(long, default_value = "./fsrt-remote.toml", value_hint = ValueHint::FilePath)]
@@ -53,13 +57,11 @@ impl InvokeExtensionArgs {
 }
 
 pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
-    let manifest_path = find_manifest_path(&args.app_dir)?;
-    let manifest_text = fs::read_to_string(manifest_path)?;
-    let manifest: forge_loader::manifest::ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
+    let app_id = resolve_app_id(args.app_id.as_deref(), args.app_dir.as_deref())?;
     let module_key = args.module_key.as_str();
 
     let config = forge_pen_test::FsrtRemoteConfig::from_path(&args.config)?;
-    let tester = forge_pen_test::ForgePenTester::new(&manifest, config)?;
+    let tester = forge_pen_test::ForgePenTester::new(&app_id, config)?;
     let ctx = args.ctx.clone().unwrap_or_else(|| serde_json::json!({}));
 
     if args.dry_run {

--- a/crates/fsrt/src/commands/invoke_extension.rs
+++ b/crates/fsrt/src/commands/invoke_extension.rs
@@ -12,14 +12,19 @@ const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
 /// `invoke-extension` arguments.
 #[derive(Args, Debug)]
+#[command(allow_missing_positional = true)]
 pub(crate) struct InvokeExtensionArgs {
-    /// Resolver function key, optionally prefixed with `resolver.`.
-    #[arg(name = "FUNCTION")]
-    function: String,
+    /// Resolver function key, optionally prefixed with `resolver.`. Required for the resolver entrypoint.
+    #[arg(name = "FUNCTION", required_if_eq("entrypoint", "resolver"))]
+    function: Option<String>,
 
-    /// Deployed resolver module key.
+    /// Deployed module key.
     #[arg(name = "MODULE_KEY")]
     module_key: String,
+
+    /// Manifest entrypoint path used to select the function or endpoint.
+    #[arg(long)]
+    entrypoint: Option<String>,
 
     /// Optional invocation payload as a JSON object.
     #[arg(long, value_name = "JSON", value_parser = parse_json)]
@@ -67,7 +72,8 @@ pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
     if args.dry_run {
         let request = tester.invoke_extension_request(
             module_key,
-            &args.function,
+            args.entrypoint.as_deref(),
+            args.function.as_deref(),
             args.payload.as_ref(),
             &ctx,
             REDACTED_FCT,
@@ -84,7 +90,8 @@ pub(super) fn run(args: &InvokeExtensionArgs) -> Result<()> {
 
     let outcome = tester.invoke_extension(
         module_key,
-        &args.function,
+        args.entrypoint.as_deref(),
+        args.function.as_deref(),
         args.payload.as_ref(),
         &ctx,
         &context_token,

--- a/crates/fsrt/src/commands/mint_fct.rs
+++ b/crates/fsrt/src/commands/mint_fct.rs
@@ -1,11 +1,11 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::{Args, ValueHint};
 use tracing::info;
 
-use crate::{Result, forge_project::find_manifest_path};
+use crate::Result;
 
-use super::parse_json;
+use super::{parse_json, resolve_app_id};
 
 /// `mint-fct` arguments.
 #[derive(Args, Debug)]
@@ -14,9 +14,13 @@ pub(crate) struct MintFctArgs {
     #[arg(name = "MODULE_KEY")]
     module_key: String,
 
-    /// Forge app directory.
-    #[arg(long, default_value = ".", value_hint = ValueHint::DirPath)]
-    app_dir: PathBuf,
+    /// Forge app ID. Does not require a local manifest.
+    #[arg(long, value_name = "APP_ID", conflicts_with = "app_dir")]
+    app_id: Option<String>,
+
+    /// Forge app directory. Defaults to the current directory when --app-id is omitted.
+    #[arg(long, value_hint = ValueHint::DirPath, conflicts_with = "app_id")]
+    app_dir: Option<PathBuf>,
 
     /// Path to `fsrt-remote.toml`.
     #[arg(long, default_value = "./fsrt-remote.toml", value_hint = ValueHint::FilePath)]
@@ -38,12 +42,9 @@ impl MintFctArgs {
 }
 
 pub(super) fn run(args: &MintFctArgs) -> Result<()> {
-    let manifest_path = find_manifest_path(&args.app_dir)?;
-    let manifest_text = fs::read_to_string(manifest_path)?;
-    let manifest: forge_loader::manifest::ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
-
+    let app_id = resolve_app_id(args.app_id.as_deref(), args.app_dir.as_deref())?;
     let config = forge_pen_test::FsrtRemoteConfig::from_path(&args.config)?;
-    let tester = forge_pen_test::ForgePenTester::new(&manifest, config)?;
+    let tester = forge_pen_test::ForgePenTester::new(&app_id, config)?;
     let ctx = args.ctx.clone().unwrap_or_else(|| serde_json::json!({}));
     if args.dry_run {
         let request = tester.mint_fct_request(&args.module_key, &ctx)?;

--- a/crates/fsrt/src/commands/mint_fit.rs
+++ b/crates/fsrt/src/commands/mint_fit.rs
@@ -1,11 +1,11 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::{Args, ValueHint};
 use serde_json::Value;
 
-use crate::{Result, forge_project::find_manifest_path};
+use crate::Result;
 
-use super::parse_json;
+use super::{parse_json, resolve_app_id};
 
 const REDACTED_FCT: &str = "<FCT selected at runtime>";
 
@@ -38,9 +38,13 @@ pub(crate) struct MintFitArgs {
     #[arg(long, conflicts_with_all = ["module_key", "ctx"])]
     fct: Option<String>,
 
-    /// Forge app directory.
-    #[arg(long, default_value = ".", value_hint = ValueHint::DirPath)]
-    app_dir: PathBuf,
+    /// Forge app ID. Does not require a local manifest.
+    #[arg(long, value_name = "APP_ID", conflicts_with = "app_dir")]
+    app_id: Option<String>,
+
+    /// Forge app directory. Defaults to the current directory when --app-id is omitted.
+    #[arg(long, value_hint = ValueHint::DirPath, conflicts_with = "app_id")]
+    app_dir: Option<PathBuf>,
 
     /// Path to `fsrt-remote.toml`.
     #[arg(long, default_value = "./fsrt-remote.toml", value_hint = ValueHint::FilePath)]
@@ -58,12 +62,9 @@ impl MintFitArgs {
 }
 
 pub(super) fn run(args: &MintFitArgs) -> Result<()> {
-    let manifest_path = find_manifest_path(&args.app_dir)?;
-    let manifest_text = fs::read_to_string(manifest_path)?;
-    let manifest: forge_loader::manifest::ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
-
+    let app_id = resolve_app_id(args.app_id.as_deref(), args.app_dir.as_deref())?;
     let config = forge_pen_test::FsrtRemoteConfig::from_path(&args.config)?;
-    let tester = forge_pen_test::ForgePenTester::new(&manifest, config)?;
+    let tester = forge_pen_test::ForgePenTester::new(&app_id, config)?;
     if args.dry_run {
         let request = tester.mint_fit_request(REDACTED_FCT, &args.remote_key)?;
         println!("variables={:#}", request.variables);

--- a/crates/fsrt/src/commands/mod.rs
+++ b/crates/fsrt/src/commands/mod.rs
@@ -34,6 +34,16 @@ fn parse_json(value: &str) -> std::result::Result<serde_json::Value, String> {
 /// CLI subcommands.
 #[derive(Subcommand, Debug)]
 pub(crate) enum Command {
+    /// Run dynamic application security testing commands.
+    Dast {
+        #[command(subcommand)]
+        command: DastCommand,
+    },
+}
+
+/// Dynamic application security testing subcommands.
+#[derive(Subcommand, Debug)]
+pub(crate) enum DastCommand {
     /// Invoke a resolver-backed extension with a tester-controlled payload.
     InvokeExtension(invoke_extension::InvokeExtensionArgs),
 
@@ -47,13 +57,27 @@ pub(crate) enum Command {
 impl Command {
     pub(crate) fn diagnostic_logging_requested(&self) -> bool {
         match self {
+            Self::Dast { command } => command.diagnostic_logging_requested(),
+        }
+    }
+
+    pub(crate) fn run(&self) -> Result<()> {
+        match self {
+            Self::Dast { command } => command.run(),
+        }
+    }
+}
+
+impl DastCommand {
+    fn diagnostic_logging_requested(&self) -> bool {
+        match self {
             Self::InvokeExtension(args) => args.diagnostic_logging_requested(),
             Self::MintFct(args) => args.diagnostic_logging_requested(),
             Self::MintFit(args) => args.diagnostic_logging_requested(),
         }
     }
 
-    pub(crate) fn run(&self) -> Result<()> {
+    fn run(&self) -> Result<()> {
         match self {
             Self::InvokeExtension(args) => invoke_extension::run(args),
             Self::MintFct(args) => mint_fct::run(args),

--- a/crates/fsrt/src/commands/mod.rs
+++ b/crates/fsrt/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub(crate) enum Command {
 /// Dynamic application security testing subcommands.
 #[derive(Subcommand, Debug)]
 pub(crate) enum DastCommand {
-    /// Invoke a resolver-backed extension with a tester-controlled payload.
+    /// Invoke a deployed extension with a tester-controlled payload.
     InvokeExtension(invoke_extension::InvokeExtensionArgs),
 
     /// Mint an FCT for a deployed module.

--- a/crates/fsrt/src/commands/mod.rs
+++ b/crates/fsrt/src/commands/mod.rs
@@ -1,10 +1,24 @@
+use std::{fs, path::Path};
+
 use clap::Subcommand;
 
-use crate::Result;
+use crate::{Result, forge_project::find_manifest_path};
 
 pub(crate) mod invoke_extension;
 pub(crate) mod mint_fct;
 pub(crate) mod mint_fit;
+
+fn resolve_app_id(app_id: Option<&str>, app_dir: Option<&Path>) -> Result<String> {
+    if let Some(app_id) = app_id {
+        return Ok(app_id.to_string());
+    }
+
+    let app_dir = app_dir.unwrap_or_else(|| Path::new("."));
+    let manifest_path = find_manifest_path(app_dir)?;
+    let manifest_text = fs::read_to_string(manifest_path)?;
+    let manifest: forge_loader::manifest::ForgeManifest<'_> = serde_yaml::from_str(&manifest_text)?;
+    Ok(manifest.app.id.to_string())
+}
 
 fn parse_json(value: &str) -> std::result::Result<serde_json::Value, String> {
     let json: serde_json::Value =

--- a/fsrt-remote.toml.example
+++ b/fsrt-remote.toml.example
@@ -1,7 +1,7 @@
 # Copy to `fsrt-remote.toml` and keep the local file untracked.
 
-# Full site origin used to resolve cloud_id (HTTPS).
-site = "https://your-site.example.com"
+# Atlassian site origin used to resolve cloud_id and access the GraphQL gateway.
+site = "https://your-site.atlassian.net"
 
 # Context ARI owner, such as "jira" or "confluence".
 product = "jira"


### PR DESCRIPTION
**Summary**
- Groups Forge penetration-testing commands under `fsrt dast`.
- Adds --app-id support and centralizes app resolution.
- Separates FCT and FIT minting into dedicated modules.
- Adds --entrypoint to invoke-extension, defaulting to resolver.
- Makes the resolver function key optional for non-resolver entrypoints.
- Sends payloads directly to plain handlers while preserving resolver dispatch.
- Updates CLI documentation and example configuration.
- Edited module_keys given, needed filtering by `core:`