### PR TITLE
EAS-4699 Ggladstone/fsrt failure fix

### DIFF
--- a/crates/forge_analyzer/src/definitions.rs
+++ b/crates/forge_analyzer/src/definitions.rs
@@ -2780,18 +2780,23 @@ impl Visit for FunctionCollector<'_> {
     }
 
     fn visit_constructor(&mut self, n: &Constructor) {
-        if let Some(class_def) = self.curr_class
-            && let DefKind::Class(class) = self.res.clone().def_ref(class_def)
-            && let Some((_, owner)) = &class
+        let owner = self.curr_class.and_then(|class_def| {
+            let DefKind::Class(class) = self.res.def_ref(class_def) else {
+                return None;
+            };
+            class
                 .pub_members
                 .iter()
-                .find(|(name, defid)| name == "constructor")
-        {
+                .find(|(name, _)| name == "constructor")
+                .map(|(_, owner)| *owner)
+        });
+
+        if let Some(owner) = owner {
             let mut argdef = ArgDefiner {
                 res: self.res,
                 module: self.module,
-                func: *owner,
-                body: Body::with_owner(*owner),
+                func: owner,
+                body: Body::with_owner(owner),
                 current_arg: Default::default(),
             };
             n.params.visit_with(&mut argdef);
@@ -2799,7 +2804,7 @@ impl Visit for FunctionCollector<'_> {
             let mut localdef = LocalDefiner {
                 res: self.res,
                 module: self.module,
-                func: *owner,
+                func: owner,
                 body,
             };
             n.body.visit_children_with(&mut localdef);
@@ -2807,7 +2812,7 @@ impl Visit for FunctionCollector<'_> {
             let mut analyzer = FunctionAnalyzer {
                 res: self.res,
                 module: self.module,
-                current_def: *owner,
+                current_def: owner,
                 assigning_to: None,
                 secret_packages: self.secret_packages,
                 body,
@@ -2832,26 +2837,29 @@ impl Visit for FunctionCollector<'_> {
                     body.set_terminator(id, Terminator::Ret);
                 }
 
-                *self.res.def_mut(*owner).expect_body() = body;
+                *self.res.def_mut(owner).expect_body() = body;
             }
         }
     }
 
     fn visit_class_method(&mut self, n: &ClassMethod) {
-        if let Some(class_def) = self.curr_class
-            && let DefKind::Class(class) = self.res.clone().def_ref(class_def)
-            && let Some((_, owner)) = &class.pub_members.iter().find(|(name, defid)| {
-                if let PropName::Ident(ident) = &n.key {
-                    return name == &ident.sym;
-                }
-                false
-            })
-        {
+        let owner = self.curr_class.and_then(|class_def| {
+            let DefKind::Class(class) = self.res.def_ref(class_def) else {
+                return None;
+            };
+            class
+                .pub_members
+                .iter()
+                .find(|(name, _)| matches!(&n.key, PropName::Ident(ident) if name == &ident.sym))
+                .map(|(_, owner)| *owner)
+        });
+
+        if let Some(owner) = owner {
             let mut argdef = ArgDefiner {
                 res: self.res,
                 module: self.module,
-                func: *owner,
-                body: Body::with_owner(*owner),
+                func: owner,
+                body: Body::with_owner(owner),
                 current_arg: Default::default(),
             };
             n.function.params.visit_with(&mut argdef);
@@ -2859,7 +2867,7 @@ impl Visit for FunctionCollector<'_> {
             let mut localdef = LocalDefiner {
                 res: self.res,
                 module: self.module,
-                func: *owner,
+                func: owner,
                 body,
             };
             n.function.body.visit_children_with(&mut localdef);
@@ -2867,7 +2875,7 @@ impl Visit for FunctionCollector<'_> {
             let mut analyzer = FunctionAnalyzer::new(
                 self.res,
                 self.module,
-                *owner,
+                owner,
                 self.secret_packages,
                 body,
                 self.suspicious_remotes,
@@ -2887,7 +2895,7 @@ impl Visit for FunctionCollector<'_> {
                     body.set_terminator(id, Terminator::Ret);
                 }
 
-                *self.res.def_mut(*owner).expect_body() = body;
+                *self.res.def_mut(owner).expect_body() = body;
             }
         }
     }

--- a/crates/forge_analyzer/src/definitions.rs
+++ b/crates/forge_analyzer/src/definitions.rs
@@ -2706,16 +2706,23 @@ impl Visit for LocalDefiner<'_> {
 
 impl Visit for FunctionCollector<'_> {
     fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl) {
+        let old_class = self.curr_class.take();
+        let old_function = self.curr_function.take();
+
         if let Some(defid) = self.res.default_export(self.module) {
-            // we don't need to check that it is either a class or a function because
-            // it will get caught by the respective methods.
-            self.curr_class = Some(defid);
-            self.curr_function = Some(defid);
+            match self.res.def_ref(defid) {
+                DefKind::Class(_) => self.curr_class = Some(defid),
+                DefKind::Function(_) | DefKind::Closure(_) => {
+                    self.curr_function = Some(defid);
+                }
+                _ => {}
+            }
         }
+
         n.visit_children_with(self);
 
-        self.curr_class = None;
-        self.curr_function = None;
+        self.curr_class = old_class;
+        self.curr_function = old_function;
     }
 
     fn visit_assign_expr(&mut self, n: &AssignExpr) {

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -956,19 +956,23 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
         &self,
         defid_block: DefId,
         varid: VarId,
-        mut projections: ProjectionVec,
+        projections: ProjectionVec,
     ) -> Option<(VarId, ProjectionVec)> {
         let mut current_var_id = varid;
-        for i in 0..projections.len() {
+        let mut projection_start = 0;
+        for projection_end in 0..projections.len() {
             if let Some(Value::Object(varid)) = self.get_value(
                 defid_block,
                 current_var_id,
-                Some(projvec_from_projvec(&projections[..i])),
+                Some(projvec_from_projvec(
+                    &projections[projection_start..projection_end],
+                )),
             ) {
                 current_var_id = *varid;
-                projections = projvec_from_projvec(&projections[i..]);
+                projection_start = projection_end;
             }
         }
+        let projections = projvec_from_projvec(&projections[projection_start..]);
 
         let mut visited = FxHashSet::default();
         while let Some(Value::Object(varid)) =

--- a/crates/forge_analyzer/src/interp.rs
+++ b/crates/forge_analyzer/src/interp.rs
@@ -1105,7 +1105,9 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
         // globals first (in module order so dependencies are resolved before dependents),
         // then the entry function
         for global_def in self.env().global.iter() {
-            worklist.push_back_blocks(self.env, *global_def, self.call_all);
+            if self.call_all || !self.dataflow_visited.contains(global_def) {
+                worklist.push_back_blocks(self.env, *global_def, self.call_all);
+            }
         }
         worklist.push_back_blocks(self.env, func_def, self.call_all);
         let old_body = self.curr_body.get();
@@ -1267,11 +1269,6 @@ impl<'cx, C: Runner<'cx>> Interp<'cx, C> {
         }
 
         self.curr_body.set(old_body);
-    }
-
-    /// Removes a DefId from the dataflow visited set so it can be re-analyzed.
-    pub fn reset_dataflow_visited(&mut self, def: DefId) {
-        self.dataflow_visited.remove(&def);
     }
 
     pub fn try_check_function(&mut self, def: DefId, checker: &mut C) -> Result<(), Error> {

--- a/crates/forge_analyzer/src/utils.rs
+++ b/crates/forge_analyzer/src/utils.rs
@@ -102,6 +102,7 @@ pub fn return_combinations_phi(exprs: Vec<Value>) -> Value {
             Value::Phi(value_vec) => value_vec
                 .iter()
                 .map(|Const::Literal(string)| string.clone())
+                .unique()
                 .collect(),
             Value::Const(Const::Literal(string)) => vec![string.clone()],
             _ => vec![],

--- a/crates/forge_analyzer/src/worklist.rs
+++ b/crates/forge_analyzer/src/worklist.rs
@@ -12,23 +12,28 @@ use crate::{
 pub struct WorkList<V, W> {
     pub worklist: VecDeque<(V, W)>,
     pub visited: FxHashSet<V>,
+    pending: FxHashSet<(V, W)>,
 }
 
 impl<V, W> WorkList<V, W>
 where
     V: Eq + Hash,
+    W: Eq + Hash,
 {
     #[inline]
     pub fn new() -> Self {
         Self {
             worklist: VecDeque::new(),
             visited: FxHashSet::default(),
+            pending: FxHashSet::default(),
         }
     }
 
     #[inline]
     pub fn pop_front(&mut self) -> Option<(V, W)> {
-        self.worklist.pop_front()
+        let work = self.worklist.pop_front()?;
+        self.pending.remove(&work);
+        Some(work)
     }
 
     #[inline]
@@ -44,6 +49,7 @@ where
     #[inline]
     pub fn reserve(&mut self, n: usize) {
         self.worklist.reserve(n);
+        self.pending.reserve(n);
     }
 
     #[inline]
@@ -54,16 +60,12 @@ where
     {
         self.visited.contains(key)
     }
-
-    #[inline]
-    pub fn push_back_force(&mut self, v: V, w: W) {
-        self.worklist.push_back((v, w));
-    }
 }
 
 impl<V, W> Default for WorkList<V, W>
 where
     V: Eq + Hash,
+    W: Eq + Hash,
 {
     fn default() -> Self {
         Self::new()
@@ -73,10 +75,18 @@ where
 impl<V, W> WorkList<V, W>
 where
     V: Eq + Hash + Copy,
+    W: Eq + Hash + Copy,
 {
     #[inline]
     pub fn push_back(&mut self, v: V, w: W) {
-        if self.visited.insert(v) {
+        if self.visited.insert(v) && self.pending.insert((v, w)) {
+            self.worklist.push_back((v, w));
+        }
+    }
+
+    #[inline]
+    pub fn push_back_force(&mut self, v: V, w: W) {
+        if self.pending.insert((v, w)) {
             self.worklist.push_back((v, w));
         }
     }
@@ -96,8 +106,10 @@ impl WorkList<DefId, BasicBlockId> {
             let blocks = body.iter_block_keys().map(|bb| (def, bb)).rev();
             self.worklist.reserve(blocks.len());
             for work in blocks {
-                debug!(?work, "push_front_blocks");
-                self.worklist.push_front(work);
+                if self.pending.insert(work) {
+                    debug!(?work, "push_front_blocks");
+                    self.worklist.push_front(work);
+                }
             }
             return true;
         }
@@ -117,8 +129,10 @@ impl WorkList<DefId, BasicBlockId> {
             self.worklist.reserve(body.iter_block_keys().len());
             for bb in body.iter_block_keys() {
                 let work = (def, bb);
-                debug!(?work, "push_back_blocks");
-                self.worklist.push_back(work);
+                if self.pending.insert(work) {
+                    debug!(?work, "push_back_blocks");
+                    self.worklist.push_back(work);
+                }
             }
             return true;
         }
@@ -128,10 +142,16 @@ impl WorkList<DefId, BasicBlockId> {
 
 impl<V, W> Extend<(V, W)> for WorkList<V, W>
 where
-    V: Eq + Hash,
+    V: Eq + Hash + Copy,
+    W: Eq + Hash + Copy,
 {
     #[inline]
     fn extend<T: IntoIterator<Item = (V, W)>>(&mut self, iter: T) {
-        self.worklist.extend(iter);
+        for (v, w) in iter {
+            self.push_back_force(v, w);
+        }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/forge_analyzer/src/worklist/tests.rs
+++ b/crates/forge_analyzer/src/worklist/tests.rs
@@ -1,0 +1,14 @@
+use super::WorkList;
+
+#[test]
+fn forced_work_is_coalesced_only_while_pending() {
+    let mut worklist = WorkList::new();
+
+    worklist.push_back_force(1, 2);
+    worklist.push_back_force(1, 2);
+    assert_eq!(worklist.len(), 1);
+
+    assert_eq!(worklist.pop_front(), Some((1, 2)));
+    worklist.push_back_force(1, 2);
+    assert_eq!(worklist.pop_front(), Some((1, 2)));
+}

--- a/crates/fsrt/src/forge_project.rs
+++ b/crates/fsrt/src/forge_project.rs
@@ -32,7 +32,7 @@ pub(crate) fn find_manifest_path(app_dir: &Path) -> io::Result<PathBuf> {
 }
 
 pub(crate) trait ForgeProjectTrait<'a> {
-    fn load_file(&self, path: impl AsRef<Path>, _: Arc<SourceMap>) -> Arc<SourceFile>;
+    fn load_file(&self, path: impl AsRef<Path>, _: Arc<SourceMap>) -> io::Result<Arc<SourceFile>>;
 
     #[inline]
     fn with_files_and_sourceroot<
@@ -45,22 +45,22 @@ pub(crate) trait ForgeProjectTrait<'a> {
         secret_packages: &[PackageData],
         perm_map: &mut PermMap,
         suspicious_remotes: &HashSet<String>,
-    ) -> ForgeProject<'_> {
+    ) -> crate::Result<ForgeProject<'_>> {
         let sm = Arc::<SourceMap>::default();
         let target = EsVersion::latest();
         let globals = Globals::new();
         let ctx = AppCtx::new(src);
-        let ctx = iter.into_iter().fold(ctx, |mut ctx, p| {
+        let ctx = iter.into_iter().try_fold(ctx, |mut ctx, p| {
             let sourcemap = Arc::clone(&sm);
-            GLOBALS.set(&globals, || {
+            GLOBALS.set(&globals, || -> crate::Result<_> {
                 debug!(file = %p.display(), "parsing");
-                let src = self.load_file(p.clone(), sourcemap);
+                let src = self.load_file(p.clone(), sourcemap)?;
                 debug!("loaded sourcemap");
                 let mut recovered_errors = vec![];
                 let mut module = parse_file_as_module(
                     src.as_ref(),
                     Syntax::Typescript(TsSyntax {
-                        tsx: true,
+                        tsx: p.extension().and_then(|extension| extension.to_str()) != Some("ts"),
                         decorators: true,
                         ..Default::default()
                     }),
@@ -68,14 +68,19 @@ pub(crate) trait ForgeProjectTrait<'a> {
                     None,
                     &mut recovered_errors,
                 )
-                .unwrap();
+                .map_err(|error| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Could not parse {}: {error:?}", p.display()),
+                    )
+                })?;
                 debug!("finished parsing");
                 let mut hygeine = resolver(Mark::new(), Mark::new(), true);
                 module.visit_mut_with(&mut hygeine);
                 ctx.load_module(p, module);
-                ctx
+                Ok(ctx)
             })
-        });
+        })?;
         let keys = ctx.module_ids().collect::<Vec<_>>();
         debug!(?keys);
         let env = run_resolver(
@@ -85,12 +90,12 @@ pub(crate) trait ForgeProjectTrait<'a> {
             perm_map,
             suspicious_remotes,
         );
-        ForgeProject {
+        Ok(ForgeProject {
             sm,
             ctx,
             env,
             funcs: vec![],
-        }
+        })
     }
 
     fn get_paths(&self) -> HashSet<PathBuf>;
@@ -137,8 +142,12 @@ pub(crate) struct ForgeProjectFromDir {
 }
 
 impl ForgeProjectTrait<'_> for ForgeProjectFromDir {
-    fn load_file(&self, path: impl AsRef<Path>, sourcemap: Arc<SourceMap>) -> Arc<SourceFile> {
-        sourcemap.load_file(path.as_ref()).unwrap()
+    fn load_file(
+        &self,
+        path: impl AsRef<Path>,
+        sourcemap: Arc<SourceMap>,
+    ) -> io::Result<Arc<SourceFile>> {
+        sourcemap.load_file(path.as_ref())
     }
 
     fn get_paths(&self) -> HashSet<PathBuf> {

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -158,6 +158,19 @@ impl fmt::Display for Error {
     }
 }
 
+fn contains_transpiled_async(source: &str) -> bool {
+    const TRANSPILED_ASYNC_MARKERS: [&str; 4] = [
+        "__awaiter",
+        "__generator",
+        "_asyncToGenerator",
+        "regeneratorRuntime",
+    ];
+
+    TRANSPILED_ASYNC_MARKERS
+        .iter()
+        .any(|marker| source.contains(marker))
+}
+
 struct PermissionsAndNextSelection<'a, 'b> {
     permission_vec: Vec<&'a str>,
     next_selection: NextSelection<'a, 'b>,
@@ -473,13 +486,7 @@ pub(crate) fn scan_directory<'a>(
     let name = manifest.app.name.unwrap_or_default();
 
     let transpiled_async = paths.iter().any(|path| {
-        if let Ok(data) = fs::read_to_string(path) {
-            return data
-                .lines()
-                .next()
-                .is_some_and(|data| data == "\"use strict\";" || data == "'use strict';");
-        }
-        false
+        fs::read_to_string(path).is_ok_and(|source| contains_transpiled_async(&source))
     });
 
     if transpiled_async {

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -651,11 +651,6 @@ pub(crate) fn scan_directory<'a>(
         let all_functions = proj.env.get_all_functions_and_closures();
         for func_def in &all_functions {
             let func_name = proj.env.def_name(*func_def).to_string();
-            // Reset dataflow_visited so that run() re-analyzes this function body
-            // with fresh dataflow. The entry-point pass may have marked it visited
-            // during broader module/class traversal without actually checking it as
-            // a standalone function body.
-            interp.reset_dataflow_visited(*func_def);
             if let Err(err) = interp.check_function(
                 *func_def,
                 &mut full_scan_checker,

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -842,39 +842,38 @@ fn main() -> Result<()> {
         serde_yaml::from_str(secretdata_file).expect("Failed to deserialize packages");
 
     for dir in dirs {
-        let manifest_file = find_manifest_path(&dir)?;
-        debug!(?manifest_file);
-
-        let manifest_text = fs::read_to_string(&manifest_file)?;
-
-        let forge_project_from_dir = ForgeProjectFromDir {
-            dir: dir.clone(),
-            manifest_file_content: manifest_text,
-        };
-
-        debug!(?dir);
-
         if let Some(path) = &args.out {
             let report = serde_json::to_string(&get_empty_report())?;
             fs::write(path, report)?;
         }
 
-        let reporter_result =
-            scan_directory(dir, &mut args, forge_project_from_dir, &secret_packages);
-        match reporter_result {
-            Result::Ok(report) => {
-                let report = serde_json::to_string(&report)?;
-                debug!("On the debug layer: Writing Report");
-                match &args.out {
-                    Some(path) => {
-                        fs::write(path, &*report)?;
-                    }
-                    None => println!("{report}"),
-                }
+        let reporter_result = (|| -> Result<Report> {
+            let manifest_file = find_manifest_path(&dir)?;
+            debug!(?manifest_file);
+
+            let manifest_text = fs::read_to_string(&manifest_file)?;
+            let forge_project_from_dir = ForgeProjectFromDir {
+                dir: dir.clone(),
+                manifest_file_content: manifest_text,
+            };
+
+            debug!(?dir);
+            scan_directory(dir, &mut args, forge_project_from_dir, &secret_packages)
+        })();
+
+        let report = match reporter_result {
+            Ok(report) => report,
+            Err(err) => {
+                let error_message = err.to_string();
+                warn!("Could not scan due to {error_message}");
+                Report::error(error_message, vec![args.appkey.clone().unwrap_or_default()])
             }
-            Result::Err(err) => {
-                warn!("Could not scan due to {err}")
-            }
+        };
+        let report = serde_json::to_string(&report)?;
+        debug!("On the debug layer: Writing Report");
+        match &args.out {
+            Some(path) => fs::write(path, &*report)?,
+            None => println!("{report}"),
         }
     }
     Ok(())

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -468,7 +468,7 @@ pub(crate) fn scan_directory<'a>(
         secret_packages,
         &mut perm_map,
         &suspicious_remotes,
-    );
+    )?;
 
     let name = manifest.app.name.unwrap_or_default();
 

--- a/crates/fsrt/src/test.rs
+++ b/crates/fsrt/src/test.rs
@@ -250,6 +250,25 @@ fn default_export_class_with_private_method_does_not_panic() {
 }
 
 #[test]
+fn transpiled_async_detection_uses_helpers_not_strict_mode() {
+    for source in [
+        "\"use strict\";\nmodule.exports = function () {};",
+        "'use strict';\nasync function run() { await work(); }",
+    ] {
+        assert!(!crate::contains_transpiled_async(source));
+    }
+
+    for source in [
+        "return __awaiter(this, void 0, void 0, function* () {});",
+        "return __generator(this, function (_a) {});",
+        "const run = _asyncToGenerator(function* () {});",
+        "regeneratorRuntime.mark(function run() {});",
+    ] {
+        assert!(crate::contains_transpiled_async(source));
+    }
+}
+
+#[test]
 fn scanners_parse_as_typed_list() {
     let args = Args::try_parse_from([
         "fsrt",

--- a/crates/fsrt/src/test.rs
+++ b/crates/fsrt/src/test.rs
@@ -227,6 +227,29 @@ pub(crate) fn scan_directory_test(
 }
 
 #[test]
+fn default_export_class_with_private_method_does_not_panic() {
+    let test_forge_project = MockForgeProject::files_from_string(
+        "// src/index.js
+        export default class Service {
+            run() {
+                return this.#privateMethod();
+            }
+
+            #privateMethod() {
+                return 'ok';
+            }
+        }
+
+        export function run() {
+            return new Service().run();
+        }
+        ",
+    );
+
+    let _ = scan_directory_test(test_forge_project);
+}
+
+#[test]
 fn scanners_parse_as_typed_list() {
     let args = Args::try_parse_from([
         "fsrt",

--- a/crates/fsrt/src/test.rs
+++ b/crates/fsrt/src/test.rs
@@ -172,8 +172,15 @@ impl<'a> MockForgeProject<'a> {
 }
 
 impl<'a> ForgeProjectTrait<'a> for MockForgeProject<'a> {
-    fn load_file(&self, p: impl AsRef<Path>, _: Arc<SourceMap>) -> Arc<SourceFile> {
-        self.files_name_to_source.get(p.as_ref()).unwrap().clone()
+    fn load_file(
+        &self,
+        p: impl AsRef<Path>,
+        _: Arc<SourceMap>,
+    ) -> std::io::Result<Arc<SourceFile>> {
+        self.files_name_to_source
+            .get(p.as_ref())
+            .cloned()
+            .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))
     }
 
     fn get_paths(&self) -> HashSet<PathBuf> {


### PR DESCRIPTION
## Summary

Improves FSRT reliability and performance when scanning large, transpiled, or class-heavy Forge applications.

This change:

- Converts source-loading and parsing failures into structured JSON error reports instead of panics or missing output.
- Fixes analyzer crashes involving nested object projections and private methods in default-exported classes.
- Prevents several sources of redundant or exponential analyzer work.
- Refines transpiled-async detection so ordinary strict-mode bundles are not rejected.
- Preserves existing auth-header findings while allowing previously timed-out applications to complete.

## Changes

### Failure handling and parsing

- Propagate source-loading and SWC parsing errors through the existing `Result` flow.
- Emit a standard FSRT JSON error report when an application cannot be scanned.
- Parse `.ts` files as TypeScript rather than TSX, avoiding generic-type syntax being interpreted as JSX.
- Detect transpiled async code using known helper markers such as `__awaiter`, `__generator`, `_asyncToGenerator`, and `regeneratorRuntime`.
- Stop treating `"use strict"` as evidence that a bundle contains unsupported transpiled async code.

### Analyzer correctness

- Keep object projection traversal within the available projection bounds.
- Correctly distinguish default-exported classes from functions while collecting definitions.
- Preserve the previous class and function context during nested traversal.
- Handle private methods in default-exported classes without panicking.

### Analyzer performance

- Deduplicate identical phi alternatives before expanding string combinations.
- Reuse completed auth-header dataflow across the full-function scan instead of repeatedly analyzing the same functions and globals.
- Avoid cloning the complete analyzer environment when resolving constructors and class methods.
- Coalesce identical pending `(function, basic block)` worklist entries while still permitting blocks to be revisited after processing.

## Validation

- `cargo fmt --check`
- `cargo test -p forge_analyzer`
- `cargo test -p fsrt`
- `cargo clippy -p forge_analyzer -p fsrt --all-targets -- -D warnings`

Reduced total Marketplace Corpus Test to under a minute.

Targeted applications confirmed the crash and performance fixes:

| Application | Previous behavior | Result after changes |
| --- | --- | --- |
| `appvibe-jira-budget` | Parser panic | Completes without panicking |
| `betechnologies.plugins.sprintrhythm` | Projection range panic | Completes without panicking |
| `com.amoeboids.apps.roadmap` | Approximately 50 seconds | Completes in under a second |
| `de.resolution.taskeggtimer` | Approximately 156 seconds | Completes in approximately 1.8 seconds |
| `de.resolution.standup` | Exceeded 212 seconds and approximately 3.8 GB RSS | Completes in approximately 1.7 seconds |