### PR TITLE
Flag unsafe endpoint handlers

### DIFF
--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -836,6 +836,38 @@ impl WithCallStack for AuthNVuln {
     fn add_call_stack(&mut self, _stack: Vec<DefId>) {}
 }
 
+pub struct RemoteUserAuthZVuln {
+    stack: String,
+    entry_func: String,
+    file: PathBuf,
+}
+
+impl IntoVuln for RemoteUserAuthZVuln {
+    fn into_vuln(self, reporter: &Reporter) -> Vulnerability {
+        Vulnerability {
+            check_name: String::new(),
+            description: String::new(),
+            recommendation: "",
+            proof: String::new(),
+            app_key: String::new(),
+            severity: Severity::High,
+            app_name: String::new(),
+            marketplace_security_requirement: "AEC Requirement 1.10",
+            date: reporter.current_date(),
+        }
+    }
+}
+
+pub struct RemoteUserAuthZChecker {
+    vulns: Vec<RemoteUserAuthZVuln>,
+}
+
+impl RemoteUserAuthZChecker {
+    pub fn into_vulns(self) -> impl IntoIterator<Item = RemoteUserAuthZVuln> {
+        self.vulns.into_iter()
+    }
+}
+
 pub struct SecretDataflow {
     needs_call: Vec<DefId>,
 }

--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -16,6 +16,7 @@ use crate::{
     worklist::WorkList,
 };
 use core::fmt;
+use std::fmt::format;
 use forge_permission_resolver::permissions_resolver::{
     PermissionHashMap, RequestType, check_url_for_permissions,
 };
@@ -841,6 +842,8 @@ pub struct UnsafeEndpoint<'a> {
 }
 
 impl<'a> UnsafeEndpoint<'a> {
+    pub const DESC: &'static str = "An endpoint declared in this manifest passes an app system token. Remote calls that pass system tokens must also *explicitly* pass the user account ID associated with the request."
+
     pub fn new(key: &'a str) -> Self {
         Self { key }
     }
@@ -849,13 +852,13 @@ impl<'a> UnsafeEndpoint<'a> {
 impl<'a> IntoVuln for UnsafeEndpoint<'a> {
     fn into_vuln(self, reporter: &Reporter) -> Vulnerability {
         Vulnerability {
-            check_name: String::new(),
-            description: String::new(),
-            recommendation: "",
-            proof: String::new(),
-            app_key: String::new(),
+            check_name: "aec-remote-auth".to_string(),
+            description: Self::DESC.to_string(),
+            recommendation: "Endpoint and remote should omit `auth.appSystemToken: true`",
+            proof: format!("Endpoint `{}` declares `auth.appSystemToken: true`", self.key),
+            app_key: reporter.app_key().to_string(),
             severity: Severity::High,
-            app_name: String::new(),
+            app_name: reporter.app_name().to_string(),
             marketplace_security_requirement: "AEC Requirement 1.10",
             date: reporter.current_date(),
         }

--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -856,45 +856,16 @@ impl<'a> IntoVuln for UnsafeEndpoint<'a> {
             check_name: "aec-remote-auth".to_string(),
             description: Self::DESC.to_string(),
             recommendation: "Endpoint and remote should omit `auth.appSystemToken: true`",
-            proof: format!("Endpoint `{}` declares `auth.appSystemToken: true`", self.key),
+            proof: format!(
+                "Endpoint `{}` declares `auth.appSystemToken: true`",
+                self.key
+            ),
             app_key: reporter.app_key().to_string(),
             severity: Severity::High,
             app_name: reporter.app_name().to_string(),
             marketplace_security_requirement: "AEC Requirement 1.10",
             date: reporter.current_date(),
         }
-    }
-}
-
-pub struct RemoteUserAuthZVuln {
-    stack: String,
-    entry_func: String,
-    file: PathBuf,
-}
-
-impl IntoVuln for RemoteUserAuthZVuln {
-    fn into_vuln(self, reporter: &Reporter) -> Vulnerability {
-        Vulnerability {
-            check_name: String::new(),
-            description: String::new(),
-            recommendation: "",
-            proof: String::new(),
-            app_key: String::new(),
-            severity: Severity::High,
-            app_name: String::new(),
-            marketplace_security_requirement: "AEC Requirement 1.10",
-            date: reporter.current_date(),
-        }
-    }
-}
-
-pub struct RemoteUserAuthZChecker {
-    vulns: Vec<RemoteUserAuthZVuln>,
-}
-
-impl RemoteUserAuthZChecker {
-    pub fn into_vulns(self) -> impl IntoIterator<Item = RemoteUserAuthZVuln> {
-        self.vulns.into_iter()
     }
 }
 

--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -836,6 +836,32 @@ impl WithCallStack for AuthNVuln {
     fn add_call_stack(&mut self, _stack: Vec<DefId>) {}
 }
 
+pub struct UnsafeEndpoint<'a> {
+    key: &'a str,
+}
+
+impl<'a> UnsafeEndpoint<'a> {
+    pub fn new(key: &'a str) -> Self {
+        Self { key }
+    }
+}
+
+impl<'a> IntoVuln for UnsafeEndpoint<'a> {
+    fn into_vuln(self, reporter: &Reporter) -> Vulnerability {
+        Vulnerability {
+            check_name: String::new(),
+            description: String::new(),
+            recommendation: "",
+            proof: String::new(),
+            app_key: String::new(),
+            severity: Severity::High,
+            app_name: String::new(),
+            marketplace_security_requirement: "AEC Requirement 1.10",
+            date: reporter.current_date(),
+        }
+    }
+}
+
 pub struct RemoteUserAuthZVuln {
     stack: String,
     entry_func: String,

--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -838,15 +838,33 @@ impl WithCallStack for AuthNVuln {
     fn add_call_stack(&mut self, _stack: Vec<DefId>) {}
 }
 
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub enum UnsafeEndpointKind {
+    Endpoint,
+    Remote,
+}
+
+impl fmt::Display for UnsafeEndpointKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            UnsafeEndpointKind::Endpoint => "Endpoint",
+            UnsafeEndpointKind::Remote => "Remote",
+        };
+
+        f.write_str(name)
+    }
+}
+
 pub struct UnsafeEndpoint<'a> {
     key: &'a str,
+    kind: UnsafeEndpointKind,
 }
 
 impl<'a> UnsafeEndpoint<'a> {
-    pub const DESC: &'static str = "An endpoint declared in this manifest passes an app system token. Remote calls that pass system tokens must also *explicitly* pass the user account ID associated with the request.";
+    pub const DESC: &'static str = "A remote endpoint declared in this manifest passes an app system token. Remote calls that pass system tokens must also *explicitly* pass the user account ID associated with the request.";
 
-    pub fn new(key: &'a str) -> Self {
-        Self { key }
+    pub fn new(kind: UnsafeEndpointKind, key: &'a str) -> Self {
+        Self { key, kind }
     }
 }
 
@@ -855,10 +873,10 @@ impl<'a> IntoVuln for UnsafeEndpoint<'a> {
         Vulnerability {
             check_name: "aec-remote-auth".to_string(),
             description: Self::DESC.to_string(),
-            recommendation: "Endpoint and remote should omit `auth.appSystemToken: true`",
+            recommendation: "Endpoints and remotes should omit `auth.appSystemToken: true`",
             proof: format!(
-                "Endpoint `{}` declares `auth.appSystemToken: true`",
-                self.key
+                "{} `{}` declares `auth.appSystemToken: true`",
+                self.kind, self.key
             ),
             app_key: reporter.app_key().to_string(),
             severity: Severity::High,

--- a/crates/forge_analyzer/src/checkers.rs
+++ b/crates/forge_analyzer/src/checkers.rs
@@ -15,11 +15,12 @@ use crate::{
     utils::{add_elements_to_intrinsic_struct, convert_lit_to_raw, translate_request_type},
     worklist::WorkList,
 };
+
 use core::fmt;
-use std::fmt::format;
 use forge_permission_resolver::permissions_resolver::{
     PermissionHashMap, RequestType, check_url_for_permissions,
 };
+
 use forge_utils::FxHashMap;
 use itertools::Itertools;
 use regex::{Regex, RegexSet};
@@ -842,7 +843,7 @@ pub struct UnsafeEndpoint<'a> {
 }
 
 impl<'a> UnsafeEndpoint<'a> {
-    pub const DESC: &'static str = "An endpoint declared in this manifest passes an app system token. Remote calls that pass system tokens must also *explicitly* pass the user account ID associated with the request."
+    pub const DESC: &'static str = "An endpoint declared in this manifest passes an app system token. Remote calls that pass system tokens must also *explicitly* pass the user account ID associated with the request.";
 
     pub fn new(key: &'a str) -> Self {
         Self { key }

--- a/crates/forge_loader/src/manifest.rs
+++ b/crates/forge_loader/src/manifest.rs
@@ -87,6 +87,13 @@ pub struct FunctionMod<'a> {
     pub providers: Option<AuthProviders<'a>>,
 }
 
+#[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct EndpointMod<'a> {
+    pub key: &'a str,
+    pub remote: &'a str,
+    pub auth: Option<RemoteAuth>,
+}
+
 // https://developer.atlassian.com/platform/forge/manifest-reference/modules/consumer/
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Consumer<'a> {
@@ -325,6 +332,8 @@ pub struct ForgeModules<'a> {
     pub consumers: Vec<Consumer<'a>>,
     #[serde(rename = "function", default, borrow)]
     pub functions: Vec<FunctionMod<'a>>,
+    #[serde(rename = "endpoint", default, borrow)]
+    pub endpoint: Vec<EndpointMod<'a>>,
     #[serde(rename = "webtrigger", default, borrow)]
     webtriggers: Vec<RawTrigger<'a>>,
     #[serde(rename = "trigger", default, borrow)]
@@ -522,29 +531,29 @@ pub struct Remotes {
     pub operations: Vec<String>,
 }
 
+pub fn passes_user_auth(auth: &Option<RemoteAuth>) -> bool {
+    let Some(auth) = auth else { return false };
+
+    let Some(user_auth) = &auth.app_user_token else {
+        return false;
+    };
+
+    user_auth.enabled
+}
+
+pub fn passes_system_auth(auth: &Option<RemoteAuth>) -> bool {
+    let Some(auth) = auth else { return false };
+
+    let Some(system_auth) = &auth.app_system_token else {
+        return false;
+    };
+
+    system_auth.enabled
+}
+
 impl Remotes {
     pub fn contains_auth(&self) -> bool {
         self.auth.is_some()
-    }
-
-    pub fn passes_user_auth(&self) -> bool {
-        let Some(auth) = &self.auth else { return false };
-
-        let Some(user_auth) = &auth.app_user_token else {
-            return false;
-        };
-
-        user_auth.enabled
-    }
-
-    pub fn passes_system_auth(&self) -> bool {
-        let Some(auth) = &self.auth else { return false };
-
-        let Some(system_auth) = &auth.app_system_token else {
-            return false;
-        };
-
-        system_auth.enabled
     }
 }
 
@@ -798,6 +807,7 @@ impl<'a> ForgeModules<'a> {
             custom_field,
             consumers,
             functions,
+            endpoint,
             event_triggers: _,
             scheduled_triggers: _,
             api_routes,

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -46,7 +46,8 @@ use crate::{
     forge_project::{ForgeProjectFromDir, ForgeProjectTrait, find_manifest_path},
     interpreter::InterpreterFactory,
 };
-use forge_loader::manifest::{self, Entrypoint};
+
+use forge_loader::manifest::{self, EndpointMod, Entrypoint, passes_system_auth, passes_user_auth};
 use walkdir::WalkDir;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -396,10 +397,22 @@ fn check_remotes(remotes: &Option<Vec<manifest::Remotes>>) -> HashSet<String> {
 
     let result = content
         .iter()
-        .filter(|e| e.passes_system_auth() && !e.passes_user_auth())
+        .filter(|e| passes_system_auth(&e.auth) && !passes_user_auth(&e.auth))
         .map(|e| e.key.clone());
 
     HashSet::from_iter(result)
+}
+
+fn check_unsafe_remote_endpoints<'a>(
+    privileged_remotes: &HashSet<String>,
+    endpoints: &'a Vec<EndpointMod<'a>>,
+) -> HashSet<&'a str> {
+    HashSet::from_iter(
+        endpoints
+            .iter()
+            .filter(|i| privileged_remotes.contains(i.remote) || passes_system_auth(&i.auth))
+            .map(|i| i.key),
+    )
 }
 
 fn has_remote_auth(remotes: &Option<Vec<manifest::Remotes>>) -> bool {
@@ -462,6 +475,9 @@ pub(crate) fn scan_directory<'a>(
     sorted_paths.sort();
 
     let suspicious_remotes = check_remotes(&manifest.remotes);
+    let _unsafe_endps =
+        check_unsafe_remote_endpoints(&suspicious_remotes, &manifest.modules.endpoint);
+
     let mut proj = project.with_files_and_sourceroot(
         Path::new("src"),
         sorted_paths,

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -47,7 +47,9 @@ use crate::{
     interpreter::InterpreterFactory,
 };
 
-use forge_loader::manifest::{self, EndpointMod, Entrypoint, passes_system_auth, passes_user_auth};
+use forge_loader::manifest::{
+    self, EndpointMod, Entrypoint, Remotes, passes_system_auth, passes_user_auth,
+};
 use walkdir::WalkDir;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -404,15 +406,24 @@ fn check_remotes(remotes: &Option<Vec<manifest::Remotes>>) -> HashSet<String> {
 }
 
 fn check_unsafe_remote_endpoints<'a>(
-    privileged_remotes: &HashSet<String>,
+    remotes: &Option<Vec<Remotes>>,
     endpoints: &Vec<EndpointMod<'a>>,
 ) -> HashSet<String> {
-    HashSet::from_iter(
-        endpoints
+    let endp_iter = endpoints
+        .iter()
+        .filter(|i| passes_system_auth(&i.auth))
+        .map(|i| i.key.to_string());
+
+    if let Some(remotes) = remotes {
+        let remote_iter = remotes
             .iter()
-            .filter(|i| privileged_remotes.contains(i.remote) || passes_system_auth(&i.auth))
-            .map(|i| i.key.to_string()),
-    )
+            .filter(|i| passes_system_auth(&i.auth))
+            .map(|i| i.key.to_string());
+
+        HashSet::from_iter(std::iter::chain(endp_iter, remote_iter))
+    } else {
+        HashSet::from_iter(endp_iter)
+    }
 }
 
 fn has_remote_auth(remotes: &Option<Vec<manifest::Remotes>>) -> bool {
@@ -476,7 +487,7 @@ pub(crate) fn scan_directory<'a>(
 
     let suspicious_remotes = check_remotes(&manifest.remotes);
     let _unsafe_endps =
-        check_unsafe_remote_endpoints(&suspicious_remotes, &manifest.modules.endpoint);
+        check_unsafe_remote_endpoints(&manifest.remotes, &manifest.modules.endpoint);
 
     let mut proj = project.with_files_and_sourceroot(
         Path::new("src"),

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -35,6 +35,7 @@ use forge_analyzer::{
     checkers::{
         AuthHeaderChecker, AuthZChecker, AuthenticateChecker, ForgeRuntimeVersionPolicyChecker,
         PermissionChecker, PermissionVuln, SecretChecker, SecretType, UnsafeEndpoint,
+        UnsafeEndpointKind,
     },
     ctx::ModId,
     definitions::{Const, DefId, PackageData, Value},
@@ -408,17 +409,17 @@ fn check_remotes(remotes: &Option<Vec<manifest::Remotes>>) -> HashSet<String> {
 fn check_unsafe_remote_endpoints<'a>(
     remotes: &Option<Vec<Remotes>>,
     endpoints: &Vec<EndpointMod<'a>>,
-) -> HashSet<String> {
+) -> HashSet<(UnsafeEndpointKind, String)> {
     let endp_iter = endpoints
         .iter()
         .filter(|i| passes_system_auth(&i.auth))
-        .map(|i| i.key.to_string());
+        .map(|i| (UnsafeEndpointKind::Endpoint, i.key.to_string()));
 
     if let Some(remotes) = remotes {
         let remote_iter = remotes
             .iter()
             .filter(|i| passes_system_auth(&i.auth))
-            .map(|i| i.key.to_string());
+            .map(|i| (UnsafeEndpointKind::Remote, i.key.to_string()));
 
         HashSet::from_iter(std::iter::chain(endp_iter, remote_iter))
     } else {
@@ -486,8 +487,7 @@ pub(crate) fn scan_directory<'a>(
     sorted_paths.sort();
 
     let suspicious_remotes = check_remotes(&manifest.remotes);
-    let _unsafe_endps =
-        check_unsafe_remote_endpoints(&manifest.remotes, &manifest.modules.endpoint);
+    let unsafe_endps = check_unsafe_remote_endpoints(&manifest.remotes, &manifest.modules.endpoint);
 
     let mut proj = project.with_files_and_sourceroot(
         Path::new("src"),
@@ -573,9 +573,16 @@ pub(crate) fn scan_directory<'a>(
 
     let mut reporter = Reporter::new();
     reporter.add_app(opts.appkey.clone().unwrap_or_default(), name.to_owned());
-    reporter.add_vulnerabilities(_unsafe_endps.iter().map(|i| UnsafeEndpoint::new(i)));
     if let Some(vuln) = runtime_policy_vuln {
         reporter.add_vulnerabilities([vuln]);
+    }
+
+    if opts.enable_aec_mode {
+        reporter.add_vulnerabilities(
+            unsafe_endps
+                .iter()
+                .map(|(kind, name)| UnsafeEndpoint::new(*kind, name)),
+        );
     }
 
     let mut secret_checker = SecretChecker::new();

--- a/crates/fsrt/src/main.rs
+++ b/crates/fsrt/src/main.rs
@@ -34,7 +34,7 @@ use tracing_tree::HierarchicalLayer;
 use forge_analyzer::{
     checkers::{
         AuthHeaderChecker, AuthZChecker, AuthenticateChecker, ForgeRuntimeVersionPolicyChecker,
-        PermissionChecker, PermissionVuln, SecretChecker, SecretType,
+        PermissionChecker, PermissionVuln, SecretChecker, SecretType, UnsafeEndpoint,
     },
     ctx::ModId,
     definitions::{Const, DefId, PackageData, Value},
@@ -405,13 +405,13 @@ fn check_remotes(remotes: &Option<Vec<manifest::Remotes>>) -> HashSet<String> {
 
 fn check_unsafe_remote_endpoints<'a>(
     privileged_remotes: &HashSet<String>,
-    endpoints: &'a Vec<EndpointMod<'a>>,
-) -> HashSet<&'a str> {
+    endpoints: &Vec<EndpointMod<'a>>,
+) -> HashSet<String> {
     HashSet::from_iter(
         endpoints
             .iter()
             .filter(|i| privileged_remotes.contains(i.remote) || passes_system_auth(&i.auth))
-            .map(|i| i.key),
+            .map(|i| i.key.to_string()),
     )
 }
 
@@ -562,6 +562,7 @@ pub(crate) fn scan_directory<'a>(
 
     let mut reporter = Reporter::new();
     reporter.add_app(opts.appkey.clone().unwrap_or_default(), name.to_owned());
+    reporter.add_vulnerabilities(_unsafe_endps.iter().map(|i| UnsafeEndpoint::new(i)));
     if let Some(vuln) = runtime_policy_vuln {
         reporter.add_vulnerabilities([vuln]);
     }


### PR DESCRIPTION
As part of AEC requirement 1.10, apps should not be calling remotes with an OAuth system token without explicitly passing the accountID of the associated user. This PR inspects an app's manifest to flag cases where such remotes are directly registered as endpoint handlers, as this would preclude explicitly passing the accountID, and forces the remote to correctly inspect the FIT's `principal` instead.